### PR TITLE
Make PDF draw result more semantically accurate

### DIFF
--- a/Vault/Sources/CryptoDocumentExporter/PDF/PDFContentDrawerer.swift
+++ b/Vault/Sources/CryptoDocumentExporter/PDF/PDFContentDrawerer.swift
@@ -5,9 +5,13 @@ import Foundation
 /// If there's no room, it makes a new page and draws there.
 struct PDFContentDrawerer {
     /// Try to draw the content. Throw if not possible
-    let draw: () -> Result<Void, DrawError>
+    let draw: () -> Result<DrawSuccess, DrawError>
     /// Make a new page.
     let makeNewPage: () -> Void
+
+    enum DrawSuccess {
+        case didDrawToDocument
+    }
 
     enum DrawError: Error {
         /// There is no space to draw on the current page.
@@ -19,7 +23,9 @@ struct PDFContentDrawerer {
     func drawContent() {
         let result = draw()
         switch result {
-        case .success: break
+        case .success:
+            // draw is complete, nothing more to do
+            break
         case .failure(.insufficientSpace):
             makeNewPage()
             // if this fails, we can't draw, even on the next page.

--- a/Vault/Sources/CryptoDocumentExporter/PDF/PDFDataBlockDocumentRenderer.swift
+++ b/Vault/Sources/CryptoDocumentExporter/PDF/PDFDataBlockDocumentRenderer.swift
@@ -97,7 +97,7 @@ private final class PDFDocumentDrawerHelper<Layout: PageLayout> {
             if currentLayoutEngine.isFullyWithinBounds(rect: rect) {
                 attributedString.draw(in: rect)
                 contentArea.didDrawContent(at: rect)
-                return .success(())
+                return .success(.didDrawToDocument)
             } else {
                 return .failure(.insufficientSpace)
             }
@@ -128,7 +128,7 @@ private final class PDFDocumentDrawerHelper<Layout: PageLayout> {
                 }
                 image.draw(in: rect)
                 contentArea.didDrawContent(at: rect)
-                return .success(())
+                return .success(.didDrawToDocument)
             } makeNewPage: { [self] in
                 startNextPage()
                 currentImageNumberOnPage = 0

--- a/Vault/Tests/CryptoDocumentExporterTests/PDFContentDrawererTests.swift
+++ b/Vault/Tests/CryptoDocumentExporterTests/PDFContentDrawererTests.swift
@@ -8,7 +8,7 @@ final class PDFContentDrawererTests: XCTestCase {
         var executions = 0
         let sut = PDFContentDrawerer {
             executions += 1
-            return .success(())
+            return .success(.didDrawToDocument)
         } makeNewPage: {
             // noop
         }
@@ -49,7 +49,7 @@ final class PDFContentDrawererTests: XCTestCase {
     func test_drawContent_doesNotMakeNewPageOnSuccess() {
         var executions = 0
         let sut = PDFContentDrawerer {
-            .success(())
+            .success(.didDrawToDocument)
         } makeNewPage: {
             executions += 1
         }


### PR DESCRIPTION
- Another semantic option to indicate when there's nothing to draw
- Clearer point of use when it's a successful draw