### PR TITLE
Don't show Done action during initial creation

### DIFF
--- a/Vault/Sources/VaultiOS/Feed/Detail/VaultItemDetailView.swift
+++ b/Vault/Sources/VaultiOS/Feed/Detail/VaultItemDetailView.swift
@@ -58,7 +58,11 @@ struct VaultItemDetailView<ChildViewModel: DetailViewModel, ContentsView: View>:
             if viewModel.editingModel.isDirty {
                 saveDirtyChangesItem
             } else {
-                doneItem
+                // Don't show the "done" item during initial creation if not dirty
+                // The only option should be to cancel.
+                if !viewModel.isInitialCreation {
+                    doneItem
+                }
             }
         }
     }


### PR DESCRIPTION
- Hide the "Done" action for the non-dirty state during initial creation of a vault item.