### PR TITLE
Add field in backup payload for padding

### DIFF
--- a/Vault/Sources/VaultBackup/VaultBackupPayload.swift
+++ b/Vault/Sources/VaultBackup/VaultBackupPayload.swift
@@ -15,6 +15,12 @@ public struct VaultBackupPayload: Codable, Equatable {
     public var userDescription: String
     /// The individual items from the vault.
     public var items: [VaultBackupItem]
+    /// Arbitrary padding used to disguise the actual size of the payload.
+    /// This is a security requirement as users may have hidden items in their vault.
+    ///
+    /// This should be sufficient to disguise the number of items in the payload, but not
+    /// so large to make the payload hard to handle.
+    public var obfuscationPadding: Data
 }
 
 // MARK: - Item

--- a/Vault/Tests/VaultBackupTests/VaultBackupDecoderTests.swift
+++ b/Vault/Tests/VaultBackupTests/VaultBackupDecoderTests.swift
@@ -25,7 +25,8 @@ final class VaultBackupDecoderTests: XCTestCase {
             version: .v1,
             created: Date(timeIntervalSince1970: 1_700_575_468),
             userDescription: "my description",
-            items: []
+            items: [],
+            obfuscationPadding: Data()
         )
         let encoder = VaultBackupEncoder()
 
@@ -101,7 +102,8 @@ extension VaultBackupDecoderTests {
             version: .v1,
             created: created,
             userDescription: userDescription,
-            items: items
+            items: items,
+            obfuscationPadding: Data()
         )
     }
 }

--- a/Vault/Tests/VaultBackupTests/VaultBackupEncoderTests.swift
+++ b/Vault/Tests/VaultBackupTests/VaultBackupEncoderTests.swift
@@ -4,6 +4,11 @@ import XCTest
 @testable import VaultBackup
 
 final class VaultBackupEncoderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        isRecording = false
+    }
+
     func test_encodeVault_encodesToJSONFormat_emptyVault() throws {
         let sut = makeSUT()
         let date = Date(timeIntervalSince1970: 12345)
@@ -141,7 +146,8 @@ extension VaultBackupEncoderTests {
             version: .v1,
             created: created,
             userDescription: userDescription,
-            items: items
+            items: items,
+            obfuscationPadding: Data(hex: "abababa")
         )
     }
 }

--- a/Vault/Tests/VaultBackupTests/__Snapshots__/VaultBackupEncoderTests/test_encodeVault_encodesToJSONFormat_emptyVault.1.txt
+++ b/Vault/Tests/VaultBackupTests/__Snapshots__/VaultBackupEncoderTests/test_encodeVault_encodesToJSONFormat_emptyVault.1.txt
@@ -3,6 +3,7 @@
   "items" : [
 
   ],
+  "obfuscation_padding" : "q6urCg==",
   "user_description" : "my description",
   "version" : "1.0"
 }

--- a/Vault/Tests/VaultBackupTests/__Snapshots__/VaultBackupEncoderTests/test_encodeVault_encodesToJSONFormat_nonEmptyVault.1.txt
+++ b/Vault/Tests/VaultBackupTests/__Snapshots__/VaultBackupEncoderTests/test_encodeVault_encodesToJSONFormat_nonEmptyVault.1.txt
@@ -47,6 +47,7 @@
       "updated_date" : 345652448000
     }
   ],
+  "obfuscation_padding" : "q6urCg==",
   "user_description" : "my description again",
   "version" : "1.0"
 }

--- a/Vault/Tests/VaultBackupTests/__Snapshots__/VaultBackupEncoderTests/test_encodeVault_encodesToJSONFormat_otpCode.1.txt
+++ b/Vault/Tests/VaultBackupTests/__Snapshots__/VaultBackupEncoderTests/test_encodeVault_encodesToJSONFormat_otpCode.1.txt
@@ -22,6 +22,7 @@
       "updated_date" : 12445000
     }
   ],
+  "obfuscation_padding" : "q6urCg==",
   "user_description" : "Example vault with a single otp code",
   "version" : "1.0"
 }

--- a/Vault/Tests/VaultBackupTests/__Snapshots__/VaultBackupEncoderTests/test_encodeVault_encodesToJSONFormat_secureNote.1.txt
+++ b/Vault/Tests/VaultBackupTests/__Snapshots__/VaultBackupEncoderTests/test_encodeVault_encodesToJSONFormat_secureNote.1.txt
@@ -15,6 +15,7 @@
       "updated_date" : 19345000
     }
   ],
+  "obfuscation_padding" : "q6urCg==",
   "user_description" : "Example vault with a single note",
   "version" : "1.0"
 }


### PR DESCRIPTION
This padding will be used when encoding the vault to the backup format to help disguise the true size of the backup.