### PR TITLE
VaultBackupEncoder/Decoder

### DIFF
--- a/Vault/Sources/VaultBackup/BackupEncoder/VaultBackupDecoder.swift
+++ b/Vault/Sources/VaultBackup/BackupEncoder/VaultBackupDecoder.swift
@@ -8,8 +8,8 @@ public final class VaultBackupDecoder {
         self.key = key
     }
 
-    public func extractBackupPayload(from payload: VaultExportPayload) throws -> VaultBackupPayload {
-        let encodedVault = try VaultDecryptor(key: key).decrypt(encryptedVault: payload.encryptedVault)
+    public func extractBackupPayload(from encryptedVault: EncryptedVault) throws -> VaultBackupPayload {
+        let encodedVault = try VaultDecryptor(key: key).decrypt(encryptedVault: encryptedVault)
         let backupPayload = try IntermediateEncodedVaultDecoder().decode(encodedVault: encodedVault)
         return backupPayload
     }

--- a/Vault/Sources/VaultBackup/BackupEncoder/VaultBackupEncoder.swift
+++ b/Vault/Sources/VaultBackup/BackupEncoder/VaultBackupEncoder.swift
@@ -20,25 +20,16 @@ public final class VaultBackupEncoder {
     }
 
     /// Encodes and encrypts a vault providing a payload.
-    public func createExportPayload(
-        items: [VaultBackupItem],
-        userDescription: String
-    ) throws -> VaultExportPayload {
-        let currentDate = clock.currentDate
+    public func createExportPayload(items: [VaultBackupItem], userDescription: String) throws -> EncryptedVault {
         let payload = VaultBackupPayload(
             version: .v1_0_0,
-            created: currentDate,
+            created: clock.currentDate,
             userDescription: userDescription,
             items: items,
             obfuscationPadding: makePadding(itemsCount: items.count)
         )
         let intermediateEncoding = try IntermediateEncodedVaultEncoder().encode(vaultBackup: payload)
-        let encryptedVault = try VaultEncryptor(key: key).encrypt(encodedVault: intermediateEncoding)
-        return VaultExportPayload(
-            encryptedVault: encryptedVault,
-            userDescription: userDescription,
-            created: currentDate
-        )
+        return try VaultEncryptor(key: key).encrypt(encodedVault: intermediateEncoding)
     }
 
     private func makePadding(itemsCount: Int) -> Data {

--- a/Vault/Tests/VaultBackupTests/VaultBackupDecoderTests.swift
+++ b/Vault/Tests/VaultBackupTests/VaultBackupDecoderTests.swift
@@ -24,13 +24,8 @@ final class VaultBackupDecoderTests: XCTestCase {
             abababababababababababababababababababababababababababababababab
             """)
         )
-        let payload = VaultExportPayload(
-            encryptedVault: encryptedVault,
-            userDescription: "my description",
-            created: Date(timeIntervalSince1970: 1234)
-        )
 
-        let backup = try sut.extractBackupPayload(from: payload)
+        let backup = try sut.extractBackupPayload(from: encryptedVault)
 
         XCTAssertEqual(backup.items, [])
         XCTAssertEqual(backup.obfuscationPadding, Data())
@@ -57,13 +52,8 @@ final class VaultBackupDecoderTests: XCTestCase {
             abababababababababababababababababababababababababababababababab
             """)
         )
-        let payload = VaultExportPayload(
-            encryptedVault: encryptedVault,
-            userDescription: "my description",
-            created: Date(timeIntervalSince1970: 1234)
-        )
 
-        XCTAssertThrowsError(try sut.extractBackupPayload(from: payload))
+        XCTAssertThrowsError(try sut.extractBackupPayload(from: encryptedVault))
     }
 
     func test_extractBackupPayload_failsToDecryptMalformedAuthentication() throws {
@@ -86,13 +76,8 @@ final class VaultBackupDecoderTests: XCTestCase {
             abababababababababababababababababababababababababababababababab
             """)
         )
-        let payload = VaultExportPayload(
-            encryptedVault: encryptedVault,
-            userDescription: "my description",
-            created: Date(timeIntervalSince1970: 1234)
-        )
 
-        XCTAssertThrowsError(try sut.extractBackupPayload(from: payload))
+        XCTAssertThrowsError(try sut.extractBackupPayload(from: encryptedVault))
     }
 }
 

--- a/Vault/Tests/VaultBackupTests/VaultBackupEncoderTests.swift
+++ b/Vault/Tests/VaultBackupTests/VaultBackupEncoderTests.swift
@@ -5,30 +5,11 @@ import XCTest
 @testable import VaultBackup
 
 final class VaultBackupEncoderTests: XCTestCase {
-    func test_createExportPayload_setsCreatedDateFromCurrentClockTime() throws {
-        let clock = EpochClock(makeCurrentTime: { 1_234_567 })
-        let key = try anyKey()
-        let sut = makeSUT(clock: clock, key: key)
-
-        let payload = try sut.createExportPayload(items: [], userDescription: "")
-
-        XCTAssertEqual(payload.created, Date(timeIntervalSince1970: 1_234_567))
-    }
-
-    func test_createExportPayload_setsUserDescriptionFromParameter() throws {
-        let key = try anyKey()
-        let sut = makeSUT(key: key)
-
-        let payload = try sut.createExportPayload(items: [], userDescription: "hello world")
-
-        XCTAssertEqual(payload.userDescription, "hello world")
-    }
-
     func test_createExportPayload_encryptedVaultDataIsExpectedVault() throws {
         let key = try VaultKey(key: Data(repeating: 0xAA, count: 32), iv: Data(repeating: 0xAB, count: 32))
         let sut = makeSUT(key: key)
 
-        let payload = try sut.createExportPayload(items: [], userDescription: "hello world")
+        let encryptedVault = try sut.createExportPayload(items: [], userDescription: "hello world")
 
         // This is the encoded payload created by this test case:
 
@@ -45,17 +26,17 @@ final class VaultBackupEncoderTests: XCTestCase {
         // Manually verified data:
         // https://gchq.github.io/CyberChef/#recipe=AES_Encrypt(%7B'option':'Hex','string':'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'%7D,%7B'option':'Hex','string':'abababababababababababababababababababababababababababababababab'%7D,'GCM','Raw','Hex',%7B'option':'Hex','string':''%7D)&input=ewogICJjcmVhdGVkIiA6IDEyMzQwMDAsCiAgIml0ZW1zIiA6IFsKCiAgXSwKICAib2JmdXNjYXRpb25fcGFkZGluZyIgOiAiIiwKICAidXNlcl9kZXNjcmlwdGlvbiIgOiAiaGVsbG8gd29ybGQiLAogICJ2ZXJzaW9uIiA6ICIxLjAuMCIKfQ
 
-        XCTAssertEqual(payload.encryptedVault.data.toHexString(), """
+        XCTAssertEqual(encryptedVault.data.toHexString(), """
         0050b32570c5c022cfab78cc8b592ea4467e1356fe76dff89c078ff3ace10\
         3d3ab72826b177505bada8cb5d66725b3b3ed5887a6ab2f9f6258ce927b13\
         e7e68c3142c6b487141659225347c2a5b21b7eead891334de0323938e6599\
         14f478e6f1995637a201b45c1c15ff9cf02d8a3e44ec07029cc2b9e4f45d0\
         ec6b60b6e9e8ac109a946e9e6391
         """)
-        XCTAssertEqual(payload.encryptedVault.authentication.toHexString(), """
+        XCTAssertEqual(encryptedVault.authentication.toHexString(), """
         837b99a7c9d7e7b4cb56fe2f863d6034
         """)
-        XCTAssertEqual(payload.encryptedVault.encryptionIV.toHexString(), """
+        XCTAssertEqual(encryptedVault.encryptionIV.toHexString(), """
         abababababababababababababababababababababababababababababababab
         """)
     }
@@ -65,7 +46,7 @@ final class VaultBackupEncoderTests: XCTestCase {
         let padding = VaultBackupEncoder.PaddingMode.fixed(data: Data(repeating: 0xF1, count: 45))
         let sut = makeSUT(key: key, paddingMode: padding)
 
-        let payload = try sut.createExportPayload(items: [], userDescription: "hello world")
+        let encryptedVault = try sut.createExportPayload(items: [], userDescription: "hello world")
 
         // This is the encoded payload created by this test case:
 
@@ -82,7 +63,7 @@ final class VaultBackupEncoderTests: XCTestCase {
         // Manually verified data:
         // https://gchq.github.io/CyberChef/#recipe=AES_Encrypt(%7B'option':'Hex','string':'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'%7D,%7B'option':'Hex','string':'abababababababababababababababababababababababababababababababab'%7D,'GCM','Raw','Hex',%7B'option':'Hex','string':''%7D)&input=ewogICJjcmVhdGVkIiA6IDEyMzQwMDAsCiAgIml0ZW1zIiA6IFsKCiAgXSwKICAib2JmdXNjYXRpb25fcGFkZGluZyIgOiAiOGZIeDhmSHg4Zkh4OGZIeDhmSHg4Zkh4OGZIeDhmSHg4Zkh4OGZIeDhmSHg4Zkh4OGZIeDhmSHg4Zkh4IiwKICAidXNlcl9kZXNjcmlwdGlvbiIgOiAiaGVsbG8gd29ybGQiLAogICJ2ZXJzaW9uIiA6ICIxLjAuMCIKfQ
 
-        XCTAssertEqual(payload.encryptedVault.data.toHexString(), """
+        XCTAssertEqual(encryptedVault.data.toHexString(), """
         0050b32570c5c022cfab78cc8b592ea4467e1356fe76dff89c078ff3ace10\
         3d3ab72826b177505bada8cb5d66725b3b3ed5887a6ab2f9f6258ce927b13\
         e7e68c3142c6b4871416593819059abdf62675b7cc862f10f5193369f0658\
@@ -91,10 +72,10 @@ final class VaultBackupEncoderTests: XCTestCase {
         351ccd6978e81755622e9bc4d716bca2e8fda19841f26d96577f69f0cc67d\
         a102f91cd9b1a4c5122a9c0b71
         """)
-        XCTAssertEqual(payload.encryptedVault.authentication.toHexString(), """
+        XCTAssertEqual(encryptedVault.authentication.toHexString(), """
         f13dfab30d7ab1b70c5925d83064d5fb
         """)
-        XCTAssertEqual(payload.encryptedVault.encryptionIV.toHexString(), """
+        XCTAssertEqual(encryptedVault.encryptionIV.toHexString(), """
         abababababababababababababababababababababababababababababababab
         """)
     }


### PR DESCRIPTION
- Converts a `VaultBackupPayload` to an encoded and encrypted format and back again.
- Supports random padding to obfuscate the true amount of encrypted data.
- Gets the application layer ready to start producing backups.
- Resolves #131 