### PR TITLE
Cleanup VaultFeed test methods

### DIFF
--- a/Vault/Tests/VaultFeedTests/Helpers/SharedTestHelpers.swift
+++ b/Vault/Tests/VaultFeedTests/Helpers/SharedTestHelpers.swift
@@ -14,145 +14,120 @@ func uniqueCode() -> OTPAuthCode {
     )
 }
 
-func anyStoredNote() -> SecureNote {
-    SecureNote(title: "Some note", contents: "Some note contents")
+// MARK: - VaultItem
+
+func anySecureNote(
+    title: String = "",
+    contents: String = ""
+) -> SecureNote {
+    SecureNote(title: title, contents: contents)
 }
 
-func uniqueStoredMetadata(
-    userDescription: String = "any"
+func anyOTPAuthCode(
+    accountName: String = "",
+    issuerName: String = ""
+) -> OTPAuthCode {
+    let randomData = Data.random(count: 50)
+    return OTPAuthCode(
+        type: .totp(),
+        data: .init(
+            secret: .init(data: randomData, format: .base32),
+            accountName: accountName,
+            issuer: issuerName
+        )
+    )
+}
+
+/// A unique vault item.
+/// The default payload is any OTPAuthCode.
+func uniqueVaultItem(
+    item: VaultItem.Payload = .otpCode(anyOTPAuthCode()),
+    userDescription: String = "",
+    visibility: VaultItemVisibility = .always,
+    tags: Set<VaultItemTag.Identifier> = []
+) -> VaultItem {
+    VaultItem(
+        metadata: anyVaultItemMetadata(
+            userDescription: userDescription,
+            visibility: visibility,
+            tags: tags
+        ),
+        item: item
+    )
+}
+
+/// A unique vault item with custom metadata.
+/// The default payload is any OTPAuthCode.
+func uniqueVaultItem(
+    metadata: VaultItem.Metadata,
+    item: VaultItem.Payload = .otpCode(anyOTPAuthCode())
+) -> VaultItem {
+    VaultItem(
+        metadata: metadata,
+        item: item
+    )
+}
+
+func anyVaultItemMetadata(
+    userDescription: String = "",
+    visibility: VaultItemVisibility = .always,
+    tags: Set<VaultItemTag.Identifier> = [],
+    searchableLevel: VaultItemSearchableLevel = .full,
+    searchPassphrase: String? = nil
 ) -> VaultItem.Metadata {
     .init(
         id: UUID(),
         created: Date(),
         updated: Date(),
         userDescription: userDescription,
-        tags: [],
-        visibility: .always,
-        searchableLevel: .full,
-        searchPassphrase: nil,
+        tags: tags,
+        visibility: visibility,
+        searchableLevel: searchableLevel,
+        searchPassphrase: searchPassphrase,
         color: nil
     )
 }
 
-func uniqueVaultItem() -> VaultItem {
-    VaultItem(
-        metadata: uniqueStoredMetadata(),
-        item: .otpCode(uniqueCode())
-    )
+extension SecureNote {
+    func wrapInAnyVaultItem(
+        userDescription: String = "",
+        visibility: VaultItemVisibility = .always,
+        tags: Set<VaultItemTag.Identifier> = [],
+        searchableLevel: VaultItemSearchableLevel = .full,
+        searchPassphrase: String? = nil
+    ) -> VaultItem {
+        VaultItem(
+            metadata: anyVaultItemMetadata(
+                userDescription: userDescription,
+                visibility: visibility,
+                tags: tags,
+                searchableLevel: searchableLevel,
+                searchPassphrase: searchPassphrase
+            ),
+            item: .secureNote(self)
+        )
+    }
 }
 
-func searchableStoredOTPVaultItem(
-    userDescription: String = "",
-    accountName: String = "",
-    issuerName: String = "",
-    tags: Set<VaultItemTag.Identifier> = [],
-    visibility: VaultItemVisibility = .always,
-    searchableLevel: VaultItemSearchableLevel = .full,
-    searchPassphrase: String? = nil
-) -> VaultItem {
-    VaultItem(
-        metadata: .init(
-            id: UUID(),
-            created: Date(),
-            updated: Date(),
-            userDescription: userDescription,
-            tags: tags,
-            visibility: visibility,
-            searchableLevel: searchableLevel,
-            searchPassphrase: searchPassphrase,
-            color: nil
-        ),
-        item: .otpCode(.init(
-            type: .totp(period: 30),
-            data: .init(secret: .empty(), accountName: accountName, issuer: issuerName)
-        ))
-    )
-}
-
-func searchableStoredSecureNoteVaultItem(
-    userDescription: String = "",
-    title: String = "",
-    contents: String = "",
-    tags: Set<VaultItemTag.Identifier> = [],
-    searchableLevel: VaultItemSearchableLevel = .full,
-    secretPassphrase: String? = nil
-) -> VaultItem {
-    VaultItem(
-        metadata: .init(
-            id: UUID(),
-            created: Date(),
-            updated: Date(),
-            userDescription: userDescription,
-            tags: tags,
-            visibility: .always,
-            searchableLevel: searchableLevel,
-            searchPassphrase: secretPassphrase,
-            color: nil
-        ),
-        item: .secureNote(.init(title: title, contents: contents))
-    )
-}
-
-func uniqueVaultItem(item: VaultItem.Payload) -> VaultItem {
-    VaultItem(
-        metadata: uniqueStoredMetadata(),
-        item: item
-    )
-}
-
-func uniqueWritableVaultItem(
-    visibility: VaultItemVisibility = .always,
-    tags: Set<VaultItemTag.Identifier> = []
-) -> VaultItem.Write {
-    .init(
-        userDescription: "any",
-        color: nil,
-        item: .otpCode(uniqueCode()),
-        tags: tags,
-        visibility: visibility,
-        searchableLevel: .none,
-        searchPassphase: nil
-    )
-}
-
-func writableSearchableOTPVaultItem(
-    userDescription: String = "",
-    accountName: String = "",
-    issuerName: String = "",
-    visibility: VaultItemVisibility = .always,
-    searchableLevel: VaultItemSearchableLevel = .full,
-    tags: Set<VaultItemTag.Identifier> = [],
-    searchPassphrase: String? = nil
-) -> VaultItem.Write {
-    searchableStoredOTPVaultItem(
-        userDescription: userDescription,
-        accountName: accountName,
-        issuerName: issuerName,
-        tags: tags,
-        visibility: visibility,
-        searchableLevel: searchableLevel,
-        searchPassphrase: searchPassphrase
-    ).asWritable
-}
-
-func writableSearchableNoteVaultItem(
-    userDescription: String = "",
-    title: String = "",
-    contents: String = "",
-    tags: Set<VaultItemTag.Identifier> = [],
-    visibility: VaultItemVisibility = .always,
-    searchableLevel: VaultItemSearchableLevel = .full,
-    searchPassphrase: String? = nil
-) -> VaultItem.Write {
-    .init(
-        userDescription: userDescription,
-        color: nil,
-        item: .secureNote(.init(title: title, contents: contents)),
-        tags: tags,
-        visibility: visibility,
-        searchableLevel: searchableLevel,
-        searchPassphase: searchPassphrase
-    )
+extension OTPAuthCode {
+    func wrapInAnyVaultItem(
+        userDescription: String = "",
+        visibility: VaultItemVisibility = .always,
+        tags: Set<VaultItemTag.Identifier> = [],
+        searchableLevel: VaultItemSearchableLevel = .full,
+        searchPassphrase: String? = nil
+    ) -> VaultItem {
+        VaultItem(
+            metadata: anyVaultItemMetadata(
+                userDescription: userDescription,
+                visibility: visibility,
+                tags: tags,
+                searchableLevel: searchableLevel,
+                searchPassphrase: searchPassphrase
+            ),
+            item: .otpCode(self)
+        )
+    }
 }
 
 // MARK: - VaultItemTag

--- a/Vault/Tests/VaultFeedTests/Presentation/FeedViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/FeedViewModelTests.swift
@@ -126,7 +126,7 @@ final class FeedViewModelTests: XCTestCase {
 
         let sut = makeSUT(store: store)
 
-        try await sut.create(item: uniqueWritableVaultItem())
+        try await sut.create(item: uniqueVaultItem().asWritable)
 
         await fulfillment(of: [exp])
     }
@@ -141,7 +141,7 @@ final class FeedViewModelTests: XCTestCase {
 
         let sut = makeSUT(store: store)
 
-        try await sut.create(item: uniqueWritableVaultItem())
+        try await sut.create(item: uniqueVaultItem().asWritable)
 
         await fulfillment(of: [exp])
     }
@@ -157,7 +157,7 @@ final class FeedViewModelTests: XCTestCase {
 
         let sut = makeSUT(store: store)
 
-        try? await sut.create(item: uniqueWritableVaultItem())
+        try? await sut.create(item: uniqueVaultItem().asWritable)
 
         await fulfillment(of: [exp], timeout: 1.0)
     }
@@ -168,7 +168,7 @@ final class FeedViewModelTests: XCTestCase {
         let cache2 = VaultItemCacheMock()
         let sut = makeSUT(store: VaultStoreStub(), caches: [cache1, cache2])
 
-        try await sut.create(item: uniqueWritableVaultItem())
+        try await sut.create(item: uniqueVaultItem().asWritable)
 
         XCTAssertEqual(cache1.invalidateVaultItemDetailCacheArgValues, [])
         XCTAssertEqual(cache2.invalidateVaultItemDetailCacheArgValues, [])
@@ -184,7 +184,7 @@ final class FeedViewModelTests: XCTestCase {
 
         let sut = makeSUT(store: store)
 
-        try await sut.update(id: UUID(), item: uniqueWritableVaultItem())
+        try await sut.update(id: UUID(), item: uniqueVaultItem().asWritable)
 
         await fulfillment(of: [exp])
     }
@@ -199,7 +199,7 @@ final class FeedViewModelTests: XCTestCase {
 
         let sut = makeSUT(store: store)
 
-        try await sut.update(id: UUID(), item: uniqueWritableVaultItem())
+        try await sut.update(id: UUID(), item: uniqueVaultItem().asWritable)
 
         await fulfillment(of: [exp])
     }
@@ -215,7 +215,7 @@ final class FeedViewModelTests: XCTestCase {
 
         let sut = makeSUT(store: store)
 
-        try? await sut.update(id: UUID(), item: uniqueWritableVaultItem())
+        try? await sut.update(id: UUID(), item: uniqueVaultItem().asWritable)
 
         await fulfillment(of: [exp], timeout: 1.0)
     }
@@ -227,7 +227,7 @@ final class FeedViewModelTests: XCTestCase {
         let sut = makeSUT(store: VaultStoreStub(), caches: [cache1, cache2])
 
         let invalidateId = UUID()
-        try await sut.update(id: invalidateId, item: uniqueWritableVaultItem())
+        try await sut.update(id: invalidateId, item: uniqueVaultItem().asWritable)
 
         XCTAssertEqual(cache1.invalidateVaultItemDetailCacheArgValues, [invalidateId])
         XCTAssertEqual(cache2.invalidateVaultItemDetailCacheArgValues, [invalidateId])

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailViewModelTests.swift
@@ -64,7 +64,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
                 issuer: "my issuer"
             )
         )
-        let metadata = uniqueStoredMetadata(userDescription: "my description")
+        let metadata = anyVaultItemMetadata(userDescription: "my description")
 
         let sut = makeSUTEditing(code: code, metadata: metadata)
 
@@ -314,7 +314,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
         var code = uniqueCode()
         code.data.accountName = "account name test"
         code.data.issuer = "issuer test"
-        var metadata = uniqueStoredMetadata()
+        var metadata = anyVaultItemMetadata()
         metadata.userDescription = "description test"
         let sut = makeSUTEditing(code: code, metadata: metadata)
 
@@ -330,7 +330,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
         var code = uniqueCode()
         code.data.accountName = "account name test"
         code.data.issuer = "issuer test"
-        var metadata = uniqueStoredMetadata()
+        var metadata = anyVaultItemMetadata()
         metadata.userDescription = "description test"
         let sut = makeSUTEditing(code: code, metadata: metadata)
 
@@ -416,7 +416,7 @@ extension OTPCodeDetailViewModelTests {
     @MainActor
     private func makeSUTEditing(
         code: OTPAuthCode = uniqueCode(),
-        metadata: VaultItem.Metadata = uniqueStoredMetadata(),
+        metadata: VaultItem.Metadata = anyVaultItemMetadata(),
         editor: OTPCodeDetailEditorMock = .defaultMock(),
         file: StaticString = #filePath,
         line: UInt = #line
@@ -430,7 +430,7 @@ extension OTPCodeDetailViewModelTests {
     @MainActor
     private func makeSUT(
         code: OTPAuthCode = uniqueCode(),
-        metadata: VaultItem.Metadata = uniqueStoredMetadata(),
+        metadata: VaultItem.Metadata = anyVaultItemMetadata(),
         editor: OTPCodeDetailEditorMock = .defaultMock(),
         file: StaticString = #filePath,
         line: UInt = #line

--- a/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailViewModelTests.swift
@@ -24,7 +24,7 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
     @MainActor
     func test_init_editingModelUsesInitialData() {
         let note = SecureNote(title: "my title", contents: "my contents")
-        let metadata = uniqueStoredMetadata(userDescription: "my description")
+        let metadata = anyVaultItemMetadata(userDescription: "my description")
         let sut = makeSUTEditing(storedNote: note, storedMetadata: metadata)
 
         XCTAssertEqual(sut.editingModel.detail.title, note.title)
@@ -277,10 +277,10 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
 
     @MainActor
     func test_editingModel_initialStateUsesData() {
-        var note = anyStoredNote()
+        var note = anySecureNote()
         note.contents = "this is my contents"
         note.title = "this is my title"
-        var metadata = uniqueStoredMetadata()
+        var metadata = anyVaultItemMetadata()
         metadata.userDescription = "description test"
         let sut = makeSUTEditing(storedNote: note, storedMetadata: metadata)
 
@@ -293,10 +293,10 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
 
     @MainActor
     func test_editingModel_editingStateUsesData() {
-        var note = anyStoredNote()
+        var note = anySecureNote()
         note.contents = "this is my contents"
         note.title = "this is my title"
-        var metadata = uniqueStoredMetadata()
+        var metadata = anyVaultItemMetadata()
         metadata.userDescription = "description test"
         let sut = makeSUTEditing(storedNote: note, storedMetadata: metadata)
 
@@ -341,8 +341,8 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
 extension SecureNoteDetailViewModelTests {
     @MainActor
     private func makeSUTEditing(
-        storedNote: SecureNote = anyStoredNote(),
-        storedMetadata: VaultItem.Metadata = uniqueStoredMetadata(),
+        storedNote: SecureNote = anySecureNote(),
+        storedMetadata: VaultItem.Metadata = anyVaultItemMetadata(),
         editor: SecureNoteDetailEditorMock = SecureNoteDetailEditorMock()
     ) -> SecureNoteDetailViewModel {
         SecureNoteDetailViewModel(mode: .editing(note: storedNote, metadata: storedMetadata), editor: editor)

--- a/Vault/Tests/VaultFeedTests/Presentation/VaultFeedDetailEditorAdapterTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/VaultFeedDetailEditorAdapterTests.swift
@@ -191,7 +191,7 @@ final class VaultFeedDetailEditorAdapterTests: XCTestCase {
         let feed = VaultFeedMock()
         let sut = makeSUT(feed: feed)
 
-        var note = anyStoredNote()
+        var note = anySecureNote()
         note.title = "old title"
         note.contents = "old contents"
         var item = uniqueVaultItem(item: .secureNote(note))
@@ -230,7 +230,7 @@ final class VaultFeedDetailEditorAdapterTests: XCTestCase {
         let feed = FailingVaultFeed()
         let sut = makeSUT(feed: feed)
 
-        await XCTAssertThrowsError(try await sut.updateNote(id: UUID(), item: anyStoredNote(), edits: .new()))
+        await XCTAssertThrowsError(try await sut.updateNote(id: UUID(), item: anySecureNote(), edits: .new()))
     }
 
     @MainActor

--- a/Vault/Tests/VaultFeedTests/Storage/BackupExporterTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/BackupExporterTests.swift
@@ -45,7 +45,7 @@ final class BackupExporterTests: XCTestCase {
 
         let payload = VaultApplicationPayload(
             userDescription: "my backup",
-            items: [searchableStoredOTPVaultItem()],
+            items: [uniqueVaultItem()],
             tags: [VaultItemTag(id: .init(id: UUID()), name: "tag")]
         )
         let backup = try sut.createEncryptedBackup(payload: payload)

--- a/Vault/Tests/VaultFeedTests/Storage/BackupImporterTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/BackupImporterTests.swift
@@ -18,7 +18,7 @@ final class BackupImporterTests: XCTestCase {
     }
 
     func test_importEncryptedBackup_decodesWithItems() throws {
-        let item1 = searchableStoredOTPVaultItem()
+        let item1 = uniqueVaultItem()
         let tag1 = VaultItemTag(id: .init(id: UUID()), name: "tag1")
         let tag2 = VaultItemTag(id: .init(id: UUID()), name: "tag2")
         let password = BackupPassword(key: .random(count: 32), salt: .random(count: 32), keyDervier: .testing)

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
@@ -32,7 +32,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_retrieveAll_deliversSingleCodeOnNonEmptyStore() async throws {
-        let code = uniqueWritableVaultItem()
+        let code = uniqueVaultItem().asWritable
         try await sut.insert(item: code)
 
         let result = try await sut.retrieve(query: .all)
@@ -42,9 +42,9 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveAll_deliversMultipleCodesOnNonEmptyStore() async throws {
         let codes: [VaultItem.Write] = [
-            uniqueWritableVaultItem(),
-            uniqueWritableVaultItem(),
-            uniqueWritableVaultItem(),
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -57,9 +57,9 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveAll_hasNoSideEffectsOnNonEmptyStore() async throws {
         let codes: [VaultItem.Write] = [
-            uniqueWritableVaultItem(),
-            uniqueWritableVaultItem(),
-            uniqueWritableVaultItem(),
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -75,9 +75,9 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveAll_doesNotReturnSearchOnlyItems() async throws {
         let codes: [VaultItem.Write] = [
-            uniqueWritableVaultItem(visibility: .onlySearch),
-            uniqueWritableVaultItem(visibility: .onlySearch),
-            uniqueWritableVaultItem(visibility: .onlySearch),
+            uniqueVaultItem(visibility: .onlySearch).asWritable,
+            uniqueVaultItem(visibility: .onlySearch).asWritable,
+            uniqueVaultItem(visibility: .onlySearch).asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -90,9 +90,9 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveAll_returnsAlwaysVisibleItems() async throws {
         let codes: [VaultItem.Write] = [
-            uniqueWritableVaultItem(visibility: .always),
-            uniqueWritableVaultItem(visibility: .onlySearch),
-            uniqueWritableVaultItem(visibility: .always),
+            uniqueVaultItem(visibility: .always).asWritable,
+            uniqueVaultItem(visibility: .onlySearch).asWritable,
+            uniqueVaultItem(visibility: .always).asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -106,9 +106,9 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     @MainActor
     func test_retrieveAll_returnsCorruptedItemsAsErrors() async throws {
         let codes: [VaultItem.Write] = [
-            uniqueWritableVaultItem(),
-            uniqueWritableVaultItem(),
-            uniqueWritableVaultItem(),
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
         ]
         var ids = [UUID]()
         for code in codes {
@@ -127,9 +127,9 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     @MainActor
     func test_retrieveAll_returnsAllItemsCorrupted() async throws {
         let codes: [VaultItem.Write] = [
-            uniqueWritableVaultItem(),
-            uniqueWritableVaultItem(),
-            uniqueWritableVaultItem(),
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
         ]
         for code in codes {
             let id = try await sut.insert(item: code)
@@ -172,8 +172,8 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_returnsEmptyForNoQueryMatches() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(),
-            writableSearchableOTPVaultItem(),
+            anySecureNote().wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -187,8 +187,8 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_deliversSingleMatchOnMatchingQuery() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(userDescription: "yes"),
-            writableSearchableOTPVaultItem(userDescription: "no"),
+            anySecureNote().wrapInAnyVaultItem(userDescription: "yes").asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -203,8 +203,8 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_hasNoSideEffectsOnSingleMatch() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(userDescription: "yes"),
-            writableSearchableOTPVaultItem(userDescription: "no"),
+            anySecureNote().wrapInAnyVaultItem(userDescription: "yes").asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(userDescription: "no").asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -224,12 +224,14 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_deliversMultipleMatchesOnMatchingQuery() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableOTPVaultItem(userDescription: "no"),
-            writableSearchableNoteVaultItem(userDescription: "yes"),
-            writableSearchableOTPVaultItem(userDescription: "no"),
-            writableSearchableOTPVaultItem(userDescription: "yess"),
-            writableSearchableOTPVaultItem(userDescription: "yesss"),
-            writableSearchableOTPVaultItem(userDescription: "no"),
+            anySecureNote().wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem().asWritable,
+            uniqueVaultItem(userDescription: "no").asWritable,
+            uniqueVaultItem(userDescription: "yes").asWritable,
+            uniqueVaultItem(userDescription: "no").asWritable,
+            uniqueVaultItem(userDescription: "yess").asWritable,
+            uniqueVaultItem(userDescription: "yesss").asWritable,
+            uniqueVaultItem(userDescription: "no").asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -244,14 +246,15 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_matchesUserDescription() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(),
-            writableSearchableOTPVaultItem(userDescription: "x"),
-            writableSearchableNoteVaultItem(userDescription: "a"),
-            writableSearchableOTPVaultItem(userDescription: "c"),
-            writableSearchableOTPVaultItem(userDescription: "b"),
-            writableSearchableOTPVaultItem(userDescription: "----a----"),
-            writableSearchableOTPVaultItem(userDescription: "----A----"),
-            writableSearchableOTPVaultItem(userDescription: "x"),
+            anyOTPAuthCode().wrapInAnyVaultItem().asWritable,
+            uniqueVaultItem().asWritable,
+            uniqueVaultItem(userDescription: "x").asWritable,
+            uniqueVaultItem(userDescription: "a").asWritable,
+            uniqueVaultItem(userDescription: "c").asWritable,
+            uniqueVaultItem(userDescription: "b").asWritable,
+            uniqueVaultItem(userDescription: "----a----").asWritable,
+            uniqueVaultItem(userDescription: "----A----").asWritable,
+            uniqueVaultItem(userDescription: "x").asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -266,10 +269,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_matchesOTPAccountName() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(),
-            writableSearchableOTPVaultItem(accountName: "a"),
-            writableSearchableOTPVaultItem(accountName: "x"),
-            writableSearchableOTPVaultItem(accountName: "----A----"),
+            anySecureNote().wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(accountName: "a").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(accountName: "x").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(accountName: "----A----").wrapInAnyVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -284,10 +287,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_matchesOTPIssuer() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(),
-            writableSearchableOTPVaultItem(issuerName: "a"),
-            writableSearchableOTPVaultItem(issuerName: "x"),
-            writableSearchableOTPVaultItem(issuerName: "----A----"),
+            anySecureNote().wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(issuerName: "a").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(issuerName: "x").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(issuerName: "----A----").wrapInAnyVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -302,10 +305,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_matchesNoteDetailsTitle() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(),
-            writableSearchableNoteVaultItem(title: "a"),
-            writableSearchableNoteVaultItem(title: "x"),
-            writableSearchableNoteVaultItem(title: "----A----"),
+            anySecureNote().wrapInAnyVaultItem().asWritable,
+            anySecureNote(title: "a").wrapInAnyVaultItem().asWritable,
+            anySecureNote(title: "x").wrapInAnyVaultItem().asWritable,
+            anySecureNote(title: "----A----").wrapInAnyVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -320,10 +323,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_matchesNoteDetailsContents() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(),
-            writableSearchableNoteVaultItem(contents: "a"),
-            writableSearchableNoteVaultItem(contents: "x"),
-            writableSearchableNoteVaultItem(contents: "----A----"),
+            anySecureNote().wrapInAnyVaultItem().asWritable,
+            anySecureNote(contents: "a").wrapInAnyVaultItem().asWritable,
+            anySecureNote(contents: "x").wrapInAnyVaultItem().asWritable,
+            anySecureNote(contents: "----A----").wrapInAnyVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -340,10 +343,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
         let tag1 = try await sut.insertTag(item: anyVaultItemTag().asWritable)
 
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(tags: [tag1]),
-            writableSearchableNoteVaultItem(contents: "a", tags: [tag1]),
-            writableSearchableNoteVaultItem(contents: "x", tags: [tag1]),
-            writableSearchableNoteVaultItem(contents: "----A----"), // not tagged, so not returned
+            anySecureNote().wrapInAnyVaultItem(tags: [tag1]).asWritable,
+            anySecureNote(contents: "a").wrapInAnyVaultItem(tags: [tag1]).asWritable,
+            anySecureNote(contents: "x").wrapInAnyVaultItem(tags: [tag1]).asWritable,
+            anySecureNote(contents: "----A----").wrapInAnyVaultItem(tags: []).asWritable, // not tagged, so not returned
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -358,12 +361,12 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_combinesResultsFromDifferentFields() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(userDescription: "a"),
-            writableSearchableNoteVaultItem(title: "aa"),
-            writableSearchableNoteVaultItem(contents: "aaa"),
-            writableSearchableOTPVaultItem(userDescription: "aaaa"),
-            writableSearchableOTPVaultItem(accountName: "aaaaa"),
-            writableSearchableOTPVaultItem(issuerName: "aaaaaa"),
+            anySecureNote().wrapInAnyVaultItem(userDescription: "a").asWritable,
+            anySecureNote(title: "aa").wrapInAnyVaultItem().asWritable,
+            anySecureNote(contents: "aaa").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(userDescription: "aaaa").asWritable,
+            anyOTPAuthCode(accountName: "aaaaa").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(issuerName: "aaaaaa").wrapInAnyVaultItem().asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -377,12 +380,12 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_returnsMatchesForAllQueryStates() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(userDescription: "a", visibility: .onlySearch),
-            writableSearchableNoteVaultItem(title: "aa", visibility: .always),
-            writableSearchableNoteVaultItem(contents: "aaa", visibility: .onlySearch),
-            writableSearchableOTPVaultItem(userDescription: "aaaa", visibility: .onlySearch),
-            writableSearchableOTPVaultItem(accountName: "aaaaa", visibility: .onlySearch),
-            writableSearchableOTPVaultItem(issuerName: "aaaaaa", visibility: .onlySearch),
+            anySecureNote().wrapInAnyVaultItem(userDescription: "a", visibility: .onlySearch).asWritable,
+            anySecureNote(title: "aa").wrapInAnyVaultItem(visibility: .always).asWritable,
+            anySecureNote(contents: "aaa").wrapInAnyVaultItem(visibility: .onlySearch).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(userDescription: "aaaa", visibility: .onlySearch).asWritable,
+            anyOTPAuthCode(accountName: "aaaaa").wrapInAnyVaultItem(visibility: .onlySearch).asWritable,
+            anyOTPAuthCode(issuerName: "aaaaaa").wrapInAnyVaultItem(visibility: .onlySearch).asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -396,10 +399,11 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_doesNotReturnNotesSearchingByContent() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(contents: "aaa", searchableLevel: .onlyTitle),
-            writableSearchableNoteVaultItem(contents: "aaa", searchableLevel: .onlyPassphrase),
-            writableSearchableNoteVaultItem(contents: "aaa", searchableLevel: .none),
+            anySecureNote(contents: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyTitle).asWritable,
+            anySecureNote(contents: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyPassphrase).asWritable,
+            anySecureNote(contents: "aaa").wrapInAnyVaultItem(searchableLevel: .none).asWritable,
         ]
+
         for code in codes {
             try await sut.insert(item: code)
         }
@@ -412,9 +416,9 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_returnsNoteContentsIfEnabled() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(contents: "aaa", searchableLevel: .onlyTitle),
-            writableSearchableNoteVaultItem(contents: "aaa", searchableLevel: .onlyPassphrase),
-            writableSearchableNoteVaultItem(contents: "aaa", searchableLevel: .full),
+            anySecureNote(contents: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyTitle).asWritable,
+            anySecureNote(contents: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyPassphrase).asWritable,
+            anySecureNote(contents: "aaa").wrapInAnyVaultItem(searchableLevel: .full).asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -428,8 +432,8 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_returnsItemsSearchingByTitle() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(title: "aaa", searchableLevel: .onlyTitle),
-            writableSearchableOTPVaultItem(accountName: "aaa", searchableLevel: .onlyTitle),
+            anySecureNote(title: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyTitle).asWritable,
+            anyOTPAuthCode(accountName: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyTitle).asWritable,
         ]
         for code in codes {
             try await sut.insert(item: code)
@@ -443,8 +447,8 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_titleOnlyMatchesOTPFields() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableOTPVaultItem(accountName: "aaa", searchableLevel: .onlyTitle),
-            writableSearchableOTPVaultItem(issuerName: "aaabbb", searchableLevel: .onlyTitle),
+            anyOTPAuthCode(accountName: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyTitle).asWritable,
+            anyOTPAuthCode(issuerName: "aaabbb").wrapInAnyVaultItem(searchableLevel: .onlyTitle).asWritable,
         ]
         var insertedIDs = [UUID]()
         for code in codes {
@@ -460,17 +464,12 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_requiresExactPassphraseMatch() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(title: "aaa", searchableLevel: .onlyPassphrase, searchPassphrase: "n"),
-            writableSearchableOTPVaultItem(
-                accountName: "aaa",
-                searchableLevel: .onlyPassphrase,
-                searchPassphrase: "nn"
-            ),
-            writableSearchableOTPVaultItem(
-                accountName: "aaa",
-                searchableLevel: .onlyPassphrase,
-                searchPassphrase: "nnn"
-            ),
+            anySecureNote(title: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "n")
+                .asWritable,
+            anyOTPAuthCode(accountName: "aaa")
+                .wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "nn").asWritable,
+            anyOTPAuthCode(issuerName: "aaa")
+                .wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "nnn").asWritable,
         ]
         var insertedIDs = [UUID]()
         for code in codes {
@@ -486,10 +485,13 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_retrieveMatchingQuery_returnsPassphraseMatches() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableNoteVaultItem(title: "aaa", searchableLevel: .full),
-            writableSearchableNoteVaultItem(title: "aaa", searchableLevel: .onlyPassphrase, searchPassphrase: "a"),
-            writableSearchableOTPVaultItem(accountName: "aaa", searchableLevel: .onlyPassphrase, searchPassphrase: "b"),
-            writableSearchableOTPVaultItem(accountName: "aaa", searchableLevel: .onlyPassphrase, searchPassphrase: "q"),
+            anySecureNote(title: "aaa").wrapInAnyVaultItem(searchableLevel: .full).asWritable,
+            anySecureNote(title: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "a")
+                .asWritable,
+            anyOTPAuthCode(accountName: "aaa")
+                .wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "b").asWritable,
+            anyOTPAuthCode(accountName: "aaa")
+                .wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "q").asWritable,
         ]
         var insertedIDs = [UUID]()
         for code in codes {
@@ -510,10 +512,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     @MainActor
     func test_retrieveMatchingQuery_returnsCorruptedItemsAsErrors() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableOTPVaultItem(accountName: "aaa"),
-            writableSearchableOTPVaultItem(accountName: "aaa"),
-            writableSearchableOTPVaultItem(accountName: "bbb"), // not included
-            writableSearchableOTPVaultItem(accountName: "aaa"),
+            anyOTPAuthCode(accountName: "aaa").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(accountName: "aaa").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(accountName: "bbb").wrapInAnyVaultItem().asWritable, // not included
+            anyOTPAuthCode(accountName: "aaa").wrapInAnyVaultItem().asWritable,
         ]
         var ids = [UUID]()
         for code in codes {
@@ -533,10 +535,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     @MainActor
     func test_retrieveMatchingQuery_returnsAllItemsCorrupted() async throws {
         let codes: [VaultItem.Write] = [
-            writableSearchableOTPVaultItem(accountName: "aaa"),
-            writableSearchableOTPVaultItem(accountName: "aaa"),
-            writableSearchableOTPVaultItem(accountName: "bbb"), // not included
-            writableSearchableOTPVaultItem(accountName: "aaa"),
+            anyOTPAuthCode(accountName: "aaa").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(accountName: "aaa").wrapInAnyVaultItem().asWritable,
+            anyOTPAuthCode(accountName: "bbb").wrapInAnyVaultItem().asWritable, // not included
+            anyOTPAuthCode(accountName: "aaa").wrapInAnyVaultItem().asWritable,
         ]
         for code in codes {
             let id = try await sut.insert(item: code)
@@ -558,8 +560,8 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
         let tag1 = try await sut.insertTag(item: anyVaultItemTag().asWritable)
 
         let codes: [VaultItem.Write] = [
-            writableSearchableOTPVaultItem(tags: [tag1]),
-            writableSearchableOTPVaultItem(tags: [tag1]),
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag1]).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag1]).asWritable,
         ]
         var insertedIDs = [UUID]()
         for code in codes {
@@ -577,8 +579,8 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
         let tag1 = try await sut.insertTag(item: anyVaultItemTag().asWritable)
 
         let codes: [VaultItem.Write] = [
-            writableSearchableOTPVaultItem(tags: [tag1]),
-            writableSearchableOTPVaultItem(tags: [tag1]),
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag1]).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag1]).asWritable,
         ]
         var insertedIDs = [UUID]()
         for code in codes {
@@ -597,10 +599,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
         let tag2 = try await sut.insertTag(item: anyVaultItemTag().asWritable)
 
         let codes: [VaultItem.Write] = [
-            writableSearchableOTPVaultItem(tags: [tag1]),
-            writableSearchableOTPVaultItem(tags: [tag2]),
-            writableSearchableOTPVaultItem(tags: [tag1]),
-            writableSearchableOTPVaultItem(tags: [tag2]),
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag1]).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag2]).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag1]).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag2]).asWritable,
         ]
         var insertedIDs = [UUID]()
         for code in codes {
@@ -618,10 +620,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
         let tag1 = try await sut.insertTag(item: anyVaultItemTag().asWritable)
         let tag2 = try await sut.insertTag(item: anyVaultItemTag().asWritable)
         let codes: [VaultItem.Write] = [
-            writableSearchableOTPVaultItem(tags: [tag1, tag2]),
-            writableSearchableOTPVaultItem(tags: [tag2]),
-            writableSearchableOTPVaultItem(tags: [tag1, tag2]),
-            writableSearchableOTPVaultItem(tags: [tag2]),
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag1, tag2]).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag2]).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag1, tag2]).asWritable,
+            anyOTPAuthCode().wrapInAnyVaultItem(tags: [tag2]).asWritable,
         ]
         var insertedIDs = [UUID]()
         for code in codes {
@@ -636,16 +638,16 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_insert_deliversNoErrorOnEmptyStore() async throws {
-        try await sut.insert(item: uniqueWritableVaultItem())
+        try await sut.insert(item: uniqueVaultItem().asWritable)
     }
 
     func test_insert_deliversNoErrorOnNonEmptyStore() async throws {
-        try await sut.insert(item: uniqueWritableVaultItem())
-        try await sut.insert(item: uniqueWritableVaultItem())
+        try await sut.insert(item: uniqueVaultItem().asWritable)
+        try await sut.insert(item: uniqueVaultItem().asWritable)
     }
 
     func test_insert_doesNotOverrideExactSameEntryAsUsesNewIDToUnique() async throws {
-        let code = uniqueWritableVaultItem()
+        let code = uniqueVaultItem().asWritable
 
         try await sut.insert(item: code)
         try await sut.insert(item: code)
@@ -656,7 +658,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_insert_returnsUniqueCodeIDAfterSuccessfulInsert() async throws {
-        let code = uniqueWritableVaultItem()
+        let code = uniqueVaultItem().asWritable
 
         var ids = [UUID]()
         for _ in 0 ..< 5 {
@@ -678,7 +680,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_deleteByID_deletesSingleEntryMatchingID() async throws {
-        let code = uniqueWritableVaultItem()
+        let code = uniqueVaultItem().asWritable
 
         let id = try await sut.insert(item: code)
 
@@ -690,7 +692,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_deleteByID_hasNoEffectOnNoMatchingCode() async throws {
-        let otherCodes = [uniqueWritableVaultItem(), uniqueWritableVaultItem(), uniqueWritableVaultItem()]
+        let otherCodes = [uniqueVaultItem().asWritable, uniqueVaultItem().asWritable, uniqueVaultItem().asWritable]
         for code in otherCodes {
             try await sut.insert(item: code)
         }
@@ -704,7 +706,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
     func test_updateByID_deliversErrorIfCodeDoesNotAlreadyExist() async throws {
         do {
-            try await sut.update(id: UUID(), item: uniqueWritableVaultItem())
+            try await sut.update(id: UUID(), item: uniqueVaultItem().asWritable)
             XCTFail("Expected to throw error")
         } catch {
             // ignore
@@ -712,7 +714,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_updateByID_hasNoEffectOnEmptyStorageIfCodeDoesNotAlreadyExist() async throws {
-        try? await sut.update(id: UUID(), item: uniqueWritableVaultItem())
+        try? await sut.update(id: UUID(), item: uniqueVaultItem().asWritable)
 
         let result = try await sut.retrieve(query: .all)
         XCTAssertEqual(result.items, [])
@@ -720,12 +722,12 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_updateByID_hasNoEffectOnNonEmptyStorageIfCodeDoesNotAlreadyExist() async throws {
-        let codes = [uniqueWritableVaultItem(), uniqueWritableVaultItem(), uniqueWritableVaultItem()]
+        let codes = [uniqueVaultItem().asWritable, uniqueVaultItem().asWritable, uniqueVaultItem().asWritable]
         for code in codes {
             try await sut.insert(item: code)
         }
 
-        try? await sut.update(id: UUID(), item: uniqueWritableVaultItem())
+        try? await sut.update(id: UUID(), item: uniqueVaultItem().asWritable)
 
         let result = try await sut.retrieve(query: .all)
         XCTAssertEqual(result.items.map(\.item.otpCode), codes.map(\.item.otpCode))
@@ -733,10 +735,10 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_updateByID_updatesDataForValidCode() async throws {
-        let initialCode = uniqueWritableVaultItem()
+        let initialCode = uniqueVaultItem().asWritable
         let id = try await sut.insert(item: initialCode)
 
-        let newCode = uniqueWritableVaultItem()
+        let newCode = uniqueVaultItem().asWritable
         try await sut.update(id: id, item: newCode)
 
         let result = try await sut.retrieve(query: .all)
@@ -750,14 +752,14 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_updateByID_hasNoSideEffectsOnOtherCodes() async throws {
-        let initialCodes = [uniqueWritableVaultItem(), uniqueWritableVaultItem(), uniqueWritableVaultItem()]
+        let initialCodes = [uniqueVaultItem().asWritable, uniqueVaultItem().asWritable, uniqueVaultItem().asWritable]
         for code in initialCodes {
             try await sut.insert(item: code)
         }
 
-        let id = try await sut.insert(item: uniqueWritableVaultItem())
+        let id = try await sut.insert(item: uniqueVaultItem().asWritable)
 
-        let newCode = uniqueWritableVaultItem()
+        let newCode = uniqueVaultItem().asWritable
         try await sut.update(id: id, item: newCode)
 
         let result = try await sut.retrieve(query: .all)
@@ -773,7 +775,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
     }
 
     func test_exportVault_hasNoSideEffectsOnNonEmptyVault() async throws {
-        let initialCodes = [uniqueWritableVaultItem(), uniqueWritableVaultItem(), uniqueWritableVaultItem()]
+        let initialCodes = [uniqueVaultItem().asWritable, uniqueVaultItem().asWritable, uniqueVaultItem().asWritable]
         for code in initialCodes {
             try await sut.insert(item: code)
         }

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemEncoderTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemEncoderTests.swift
@@ -35,38 +35,38 @@ extension PersistedVaultItemEncoderTests {
             return Date(timeIntervalSince1970: currentEpochSeconds)
         })
 
-        let newItem = try sut.encode(item: uniqueWritableVaultItem())
+        let newItem = try sut.encode(item: uniqueVaultItem().asWritable)
         XCTAssertEqual(newItem.createdDate, newItem.updatedDate)
     }
 
     func test_encodeMetadata_existingItemRetainsUUID() throws {
         let sut = makeSUT()
 
-        let existing = try sut.encode(item: uniqueWritableVaultItem())
+        let existing = try sut.encode(item: uniqueVaultItem().asWritable)
         let existingID = existing.id
 
-        let newCode = try sut.encode(item: uniqueWritableVaultItem(), existing: existing)
+        let newCode = try sut.encode(item: uniqueVaultItem().asWritable, existing: existing)
         XCTAssertEqual(newCode.id, existingID, "ID should not change for update")
     }
 
     func test_encodeMetadata_existingItemRetainsCreatedDate() throws {
         let sut1 = makeSUT(currentDate: { Date(timeIntervalSince1970: 100) })
 
-        let existing = try sut1.encode(item: uniqueWritableVaultItem())
+        let existing = try sut1.encode(item: uniqueVaultItem().asWritable)
         let existingCreatedDate = existing.createdDate
 
         let sut2 = makeSUT(currentDate: { Date(timeIntervalSince1970: 200) })
-        let newCode = try sut2.encode(item: uniqueWritableVaultItem(), existing: existing)
+        let newCode = try sut2.encode(item: uniqueVaultItem().asWritable, existing: existing)
         XCTAssertEqual(newCode.createdDate, existingCreatedDate, "Date should not change for update")
     }
 
     func test_encodeMetadata_existingItemUpdatesUpdatedDate() throws {
         let sut1 = makeSUT(currentDate: { Date(timeIntervalSince1970: 100) })
 
-        let existing = try sut1.encode(item: uniqueWritableVaultItem())
+        let existing = try sut1.encode(item: uniqueVaultItem().asWritable)
 
         let sut2 = makeSUT(currentDate: { Date(timeIntervalSince1970: 200) })
-        let newCode = try sut2.encode(item: uniqueWritableVaultItem(), existing: existing)
+        let newCode = try sut2.encode(item: uniqueVaultItem().asWritable, existing: existing)
         XCTAssertEqual(newCode.updatedDate, Date(timeIntervalSince1970: 200), "Date should not change for update")
     }
 
@@ -113,7 +113,7 @@ extension PersistedVaultItemEncoderTests {
     func test_encodeMetadata_existingItemOverridesColorValues() throws {
         let sut1 = makeSUT()
 
-        var existingItem = uniqueWritableVaultItem()
+        var existingItem = uniqueVaultItem().asWritable
         existingItem.color = VaultItemColor(red: 0.1, green: 0.2, blue: 0.3)
         let existing = try sut1.encode(item: existingItem)
 
@@ -135,7 +135,7 @@ extension PersistedVaultItemEncoderTests {
 
         for (value, key) in mapping {
             let sut1 = makeSUT()
-            var existingItem = uniqueWritableVaultItem()
+            var existingItem = uniqueVaultItem().asWritable
             existingItem.visibility = value
             let existing = try sut1.encode(item: existingItem)
 
@@ -151,11 +151,11 @@ extension PersistedVaultItemEncoderTests {
 
         for (value, key) in mapping {
             let sut1 = makeSUT()
-            var item1 = uniqueWritableVaultItem()
+            var item1 = uniqueVaultItem().asWritable
             item1.visibility = .onlySearch
             let existing = try sut1.encode(item: item1)
 
-            var item2 = uniqueWritableVaultItem()
+            var item2 = uniqueVaultItem().asWritable
             item2.visibility = value
             let existing2 = try sut1.encode(item: item2, existing: existing)
 
@@ -173,7 +173,7 @@ extension PersistedVaultItemEncoderTests {
 
         for (value, key) in mapping {
             let sut1 = makeSUT()
-            var existingItem = uniqueWritableVaultItem()
+            var existingItem = uniqueVaultItem().asWritable
             existingItem.searchableLevel = value
             let existing = try sut1.encode(item: existingItem)
 
@@ -191,11 +191,11 @@ extension PersistedVaultItemEncoderTests {
 
         for (value, key) in mapping {
             let sut1 = makeSUT()
-            var item1 = uniqueWritableVaultItem()
+            var item1 = uniqueVaultItem().asWritable
             item1.searchableLevel = .none
             let existing = try sut1.encode(item: item1)
 
-            var item2 = uniqueWritableVaultItem()
+            var item2 = uniqueVaultItem().asWritable
             item2.searchableLevel = value
             let existing2 = try sut1.encode(item: item2, existing: existing)
 
@@ -205,7 +205,7 @@ extension PersistedVaultItemEncoderTests {
 
     func test_encodeMetadata_newItemEncodesEmptyTags() throws {
         let sut = makeSUT()
-        let item = uniqueWritableVaultItem(tags: [])
+        let item = uniqueVaultItem(tags: []).asWritable
 
         let encoded = try sut.encode(item: item)
         XCTAssertEqual(encoded.tags, [])
@@ -215,7 +215,7 @@ extension PersistedVaultItemEncoderTests {
         let id1 = UUID()
         let id2 = UUID()
         let sut = makeSUT()
-        let item = uniqueWritableVaultItem(tags: [.init(id: id1), .init(id: id2)])
+        let item = uniqueVaultItem(tags: [.init(id: id1), .init(id: id2)]).asWritable
 
         let persisted1 = makePersistedTag(id: id1)
         let persisted2 = makePersistedTag(id: id2)
@@ -227,10 +227,10 @@ extension PersistedVaultItemEncoderTests {
         let id1 = UUID()
         _ = makePersistedTag(id: id1)
         let sut = makeSUT()
-        let item = uniqueWritableVaultItem(tags: [.init(id: id1)])
+        let item = uniqueVaultItem(tags: [.init(id: id1)]).asWritable
         let existing = try sut.encode(item: item)
 
-        let itemNew = uniqueWritableVaultItem(tags: [])
+        let itemNew = uniqueVaultItem(tags: []).asWritable
         let encoded = try sut.encode(item: itemNew, existing: existing)
         XCTAssertEqual(encoded.tags, [])
     }
@@ -239,12 +239,12 @@ extension PersistedVaultItemEncoderTests {
         let id1 = UUID()
         _ = makePersistedTag(id: id1)
         let sut = makeSUT()
-        let item = uniqueWritableVaultItem(tags: [.init(id: id1)])
+        let item = uniqueVaultItem(tags: [.init(id: id1)]).asWritable
         let existing = try sut.encode(item: item)
 
         let id2 = UUID()
         let persisted2 = makePersistedTag(id: id2)
-        let itemNew = uniqueWritableVaultItem(tags: [.init(id: id2)])
+        let itemNew = uniqueVaultItem(tags: [.init(id: id2)]).asWritable
         let encoded = try sut.encode(item: itemNew, existing: existing)
         XCTAssertEqual(encoded.tags.map(\.id).reducedToSet(), [persisted2.id])
     }

--- a/Vault/Tests/VaultiOSTests/Helpers/SharedTestHelpers.swift
+++ b/Vault/Tests/VaultiOSTests/Helpers/SharedTestHelpers.swift
@@ -64,18 +64,6 @@ func uniqueMetadata(id: UUID = UUID()) -> VaultItem.Metadata {
     )
 }
 
-func uniqueWritableVaultItem() -> VaultItem.Write {
-    .init(
-        userDescription: "any",
-        color: nil,
-        item: .otpCode(uniqueCode()),
-        tags: [],
-        visibility: .always,
-        searchableLevel: .full,
-        searchPassphase: nil
-    )
-}
-
 func forceRunLoopAdvance() {
     RunLoop.main.run(until: Date().addingTimeInterval(0.1))
 }


### PR DESCRIPTION
Use single methods for test doubles, prefering composition over repetition.