### PR TITLE
Remove visual glitch when loading tag feed

### DIFF
--- a/Vault/Sources/VaultiOS/Feed/Reordering/ReorderableForEach.swift
+++ b/Vault/Sources/VaultiOS/Feed/Reordering/ReorderableForEach.swift
@@ -12,7 +12,6 @@ struct ReorderableForEach<Content: View, PreviewContent: View, Item: Identifiabl
     let content: (Item) -> Content
     let previewContent: (Item) -> PreviewContent
     let moveAction: (IndexSet, Int) -> Void
-    @Namespace private var forEachItems
 
     init(
         items: [Item],
@@ -36,8 +35,6 @@ struct ReorderableForEach<Content: View, PreviewContent: View, Item: Identifiabl
     var body: some View {
         ForEach(items) { item in
             content(item)
-                .matchedGeometryEffect(id: item.id, in: forEachItems)
-                .animation(.easeOut, value: items)
                 .overlay(
                     Color.white
                         .opacity(draggingItem == item ? 0.8 : 0)

--- a/Vault/Sources/VaultiOS/Feed/VaultItemFeedView.swift
+++ b/Vault/Sources/VaultiOS/Feed/VaultItemFeedView.swift
@@ -170,7 +170,6 @@ public struct VaultItemFeedView<
         } moveAction: { from, to in
             viewModel.codes.move(fromOffsets: from, toOffset: to)
         }
-        .animation(.easeOut, value: viewModel.filteringByTags)
     }
 
     private var columns: [GridItem] {


### PR DESCRIPTION
- Just show empty view before the initial load to avoid a loading blip