### PR TITLE
Item passphrase is case insensitive

### DIFF
--- a/Vault/Sources/VaultFeed/Storage/Infrastructure/SwiftData/PersistedLocalVaultStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/Infrastructure/SwiftData/PersistedLocalVaultStore.swift
@@ -83,10 +83,13 @@ extension PersistedLocalVaultStore: VaultStoreReader {
             $0.searchableLevel == full && $0.lockState == notLocked
         }
 
+        let orderedSame = ComparisonResult.orderedSame
         let passphrasePredicate = #Predicate<PersistedVaultItem> { item in
             item.searchableLevel == onlyPassphrase &&
-                // We need an EXACT match on the passphrase
-                item.searchPassphrase.flatMap { $0 == query } ?? false
+                // We need an EXACT match on the passphrase (case insensitive)
+                item.searchPassphrase.flatMap {
+                    $0.caseInsensitiveCompare(query) == orderedSame
+                } ?? false
         }
 
         let userDescriptionPredicate = #Predicate<PersistedVaultItem> {

--- a/Vault/Sources/VaultiOS/Feed/Detail/OTPCodeDetailView.swift
+++ b/Vault/Sources/VaultiOS/Feed/Detail/OTPCodeDetailView.swift
@@ -378,6 +378,9 @@ struct OTPCodeDetailView<PreviewGenerator: VaultItemPreviewViewGenerator & Vault
             }
             if viewModel.editingModel.detail.isHiddenWithPassphrase {
                 TextField(viewModel.strings.passphrasePrompt, text: $viewModel.editingModel.detail.searchPassphrase)
+                    .keyboardType(.default)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
             }
         } header: {
             Text(viewModel.strings.visibilitySectionTitle)

--- a/Vault/Sources/VaultiOS/Feed/Detail/SecureNoteDetailView.swift
+++ b/Vault/Sources/VaultiOS/Feed/Detail/SecureNoteDetailView.swift
@@ -321,6 +321,9 @@ struct SecureNoteDetailView: View {
             }
             if viewModel.editingModel.detail.isHiddenWithPassphrase {
                 TextField(viewModel.strings.passphrasePrompt, text: $viewModel.editingModel.detail.searchPassphrase)
+                    .keyboardType(.default)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
             }
         } header: {
             Text(viewModel.strings.noteVisibilityTitle)

--- a/Vault/Sources/VaultiOS/General/SearchTextField.swift
+++ b/Vault/Sources/VaultiOS/General/SearchTextField.swift
@@ -12,6 +12,9 @@ struct SearchTextField: View {
         HStack(spacing: 8) {
             TextField(title, text: $text)
                 .textFieldStyle(.plain)
+                .keyboardType(.default)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
                 .submitLabel(.done)
                 .focused($isFocused)
                 .padding(radius)

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
@@ -495,9 +495,11 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
         XCTAssertEqual(result.errors, [])
     }
 
-    func test_retrieveMatchingQuery_requiresExactPassphraseMatch() async throws {
+    func test_retrieveMatchingQuery_requiresExactPassphraseMatchCaseInsensitive() async throws {
         let codes: [VaultItem.Write] = [
             anySecureNote(title: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "n")
+                .makeWritable(),
+            anySecureNote(title: "aaa").wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "N")
                 .makeWritable(),
             anyOTPAuthCode(accountName: "aaa")
                 .wrapInAnyVaultItem(searchableLevel: .onlyPassphrase, searchPassphrase: "nn").makeWritable(),
@@ -512,7 +514,11 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
 
         let query = VaultStoreQuery(searchText: "n")
         let result = try await sut.retrieve(query: query)
-        XCTAssertEqual(result.items.map(\.metadata.id), [insertedIDs[0]], "Only the first item is an exact match")
+        XCTAssertEqual(
+            result.items.map(\.metadata.id),
+            [insertedIDs[0], insertedIDs[1]],
+            "Only the first item is an exact match"
+        )
         XCTAssertEqual(result.errors, [])
     }
 


### PR DESCRIPTION
- Searches for passphrases are case insensitive
- Disable autocorrection and auto cap when creating passphrases
- Disable autocorrection and auto cap in search bar