### PR TITLE
Ensure data integrity is maintained when deleting a tag

### DIFF
--- a/Vault/Sources/VaultFeed/Storage/Infrastructure/SwiftData/PersistedLocalVaultStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/Infrastructure/SwiftData/PersistedLocalVaultStore.swift
@@ -307,6 +307,17 @@ extension PersistedLocalVaultStore: VaultTagStoreWriter {
 
     public func deleteTag(id: Identifier<VaultItemTag>) async throws {
         do {
+            // Firstly, remove the tag from all items that contain it.
+            let tagsPredicate = makeTagsPredicate(matchingTags: [id])
+            let fetchDescriptor = FetchDescriptor(predicate: tagsPredicate)
+            let allItems: [PersistedVaultItem] = try modelContext.fetch(fetchDescriptor)
+            for item in allItems {
+                item.tags.removeAll(where: { $0.id == id.id })
+                modelContext.insert(item)
+            }
+            try modelContext.save()
+
+            // Then delete the tag itself.
             let uuid = id.id
             try modelContext.delete(model: PersistedVaultTag.self, where: #Predicate {
                 $0.id == uuid


### PR DESCRIPTION
- We need to remove the tag from any items that contain it before we can delete the tag itself
- Failure to do this violates data integrity in our CoreData model. We need to make sure the data remains consistent. The tag is not removed from the item's individual array of tags automatically.