### PR TITLE
Always show retry fetch password action if the state is required

### DIFF
--- a/Vault/Sources/VaultFeed/Storage/VaultDataModel.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultDataModel.swift
@@ -123,6 +123,16 @@ extension VaultDataModel {
         backupPassword = .notFetched
         backupPasswordLoadingState = .notLoading
     }
+
+    /// If the password hasn't been fetched, but we could retry a fetch, this will be `true`.
+    ///
+    /// It's a good indicator if we should show a "Retry Load Password" button.
+    public var showBackupPasswordRetryFetchAction: Bool {
+        switch backupPassword {
+        case .error, .notFetched: backupPasswordLoadingState.isNotLoading
+        case .notCreated, .fetched: false
+        }
+    }
 }
 
 // MARK: - Backup Password

--- a/Vault/Sources/VaultiOS/Views/Backup/BackupView.swift
+++ b/Vault/Sources/VaultiOS/Views/Backup/BackupView.swift
@@ -96,18 +96,6 @@ struct BackupView: View {
                     .foregroundStyle(.secondary)
                     .padding()
                     .containerRelativeFrame(.horizontal)
-
-                if dataModel.backupPasswordLoadingState.isNotLoading {
-                    Button {
-                        Task {
-                            await dataModel.loadBackupPassword()
-                        }
-                    } label: {
-                        FormRow(image: Image(systemName: "arrow.clockwise"), color: .blue, style: .standard) {
-                            Text("Authenticate")
-                        }
-                    }
-                }
             case let .fetched(password):
                 updateButton
                 exportButton(password: password)
@@ -125,8 +113,24 @@ struct BackupView: View {
                 .padding()
                 .containerRelativeFrame(.horizontal)
             }
+
+            if dataModel.showBackupPasswordRetryFetchAction {
+                authenticateButton
+            }
         } header: {
             Text(viewModel.strings.backupPasswordSectionTitle)
+        }
+    }
+
+    private var authenticateButton: some View {
+        Button {
+            Task {
+                await dataModel.loadBackupPassword()
+            }
+        } label: {
+            FormRow(image: Image(systemName: "arrow.clockwise"), color: .blue, style: .standard) {
+                Text("Authenticate")
+            }
         }
     }
 

--- a/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
@@ -347,6 +347,48 @@ final class VaultDataModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_showBackupPasswordRetryFetchAction_errorState() async {
+        let store = BackupPasswordStoreMock()
+        store.fetchPasswordHandler = { throw TestError() }
+        let sut = makeSUT(backupPasswordStore: store)
+
+        await sut.loadBackupPassword()
+
+        XCTAssertTrue(sut.showBackupPasswordRetryFetchAction)
+    }
+
+    @MainActor
+    func test_showBackupPasswordRetryFetchAction_notFetched() async {
+        let store = BackupPasswordStoreMock()
+        let sut = makeSUT(backupPasswordStore: store)
+
+        XCTAssertTrue(sut.showBackupPasswordRetryFetchAction)
+    }
+
+    @MainActor
+    func test_showBackupPasswordRetryFetchAction_fetched() async {
+        let store = BackupPasswordStoreMock()
+        let password = BackupPassword(key: .zero(), salt: Data(), keyDervier: .testing)
+        store.fetchPasswordHandler = { password }
+        let sut = makeSUT(backupPasswordStore: store)
+
+        await sut.loadBackupPassword()
+
+        XCTAssertFalse(sut.showBackupPasswordRetryFetchAction)
+    }
+
+    @MainActor
+    func test_showBackupPasswordRetryFetchAction_notCreated() async {
+        let store = BackupPasswordStoreMock()
+        store.fetchPasswordHandler = { nil }
+        let sut = makeSUT(backupPasswordStore: store)
+
+        await sut.loadBackupPassword()
+
+        XCTAssertFalse(sut.showBackupPasswordRetryFetchAction)
+    }
+
+    @MainActor
     func test_purgeSensitiveData_clearsBackupPassword() async {
         let store = BackupPasswordStoreMock()
         store.fetchPasswordHandler = { BackupPassword(key: .random(), salt: Data(), keyDervier: .testing) }


### PR DESCRIPTION
- There was an inconsistency where we weren't showing the retry fetch password button in all cases.
- Fix this, add a helper property to determine of this should be displayed.