### PR TITLE
Fix race condition in continuation cancellation state

### DIFF
--- a/Vault/Sources/FoundationExtensions/Extensions/Task+Continuation.swift
+++ b/Vault/Sources/FoundationExtensions/Extensions/Task+Continuation.swift
@@ -11,22 +11,32 @@ extension Task where Failure == Never {
     ) async throws -> Success {
         // The atomic here does not violate the SC model as it never blocks.
         // It's just for safely cancelling the task.
+        let isCancelled = Atomic<Bool>(initialValue: false)
         let runningTask: Atomic<Task<Void, Never>?> = .init(initialValue: nil)
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { cont in
                 let task = Task<Void, Never>.detached(priority: priority) {
-                    do {
-                        let result = try body()
-                        try Task<Never, Never>.checkCancellation()
-                        cont.resume(returning: result)
-                    } catch {
-                        cont.resume(throwing: error)
-                    }
+                    cont.resume(with: Result {
+                        try computeContinuationResult(isCancelled: isCancelled, body: body)
+                    })
                 }
                 runningTask.modify { $0 = task }
             }
         } onCancel: {
+            isCancelled.modify { $0 = true }
             runningTask.modify { $0?.cancel() }
         }
     }
+}
+
+private func computeContinuationResult<T>(
+    isCancelled: Atomic<Bool>,
+    body: @Sendable @escaping () throws -> T
+) throws -> T {
+    if isCancelled.value {
+        throw CancellationError()
+    }
+    let result = try body()
+    try Task<Never, Never>.checkCancellation()
+    return result
 }

--- a/Vault/Tests/FoundationExtensionsTests/TaskContinuationTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/TaskContinuationTests.swift
@@ -38,4 +38,50 @@ final class TaskContinuationTests: XCTestCase {
         }
         XCTAssertTrue(error is CancellationError)
     }
+
+    func test_cancelsBeforeTaskRuns() async throws {
+        let exp1 = expectation(description: "Wait for task start")
+        let exp2 = expectation(description: "The continuation should not start")
+        exp2.isInverted = true
+        let exp3 = expectation(description: "Should have thrown before here")
+        exp3.isInverted = true
+        let waiter = TaskCancellationWaiter()
+        let outer = Task {
+            exp1.fulfill()
+            await waiter.waitForTaskCancellation()
+            let result = try await Task.continuation {
+                exp2.fulfill() // should not reach here; task never starts
+                return 100
+            }
+            exp3.fulfill() // should not reach here; Cancellation error thrown from continuation
+            return result
+        }
+        await fulfillment(of: [exp1]) // wait for task to start
+
+        outer.cancel()
+
+        await fulfillment(of: [exp2, exp3], timeout: 1)
+
+        let error = await withCatchingAsyncError {
+            try await outer.result.get()
+        }
+        XCTAssertTrue(error is CancellationError)
+    }
+}
+
+// MARK: - Task Cancellation waiting helpers
+
+private typealias TaskCancellationWaiter = PendingValue<Void>
+
+extension PendingValue where Output == Void {
+    fileprivate func waitForTaskCancellation() async {
+        do {
+            // Awaiting a value will throw `CancellationError` when the Task it's part of is cancelled.
+            try await awaitValue()
+        } catch {
+            guard error is CancellationError else {
+                preconditionFailure("Expected a cancellation error!")
+            }
+        }
+    }
 }


### PR DESCRIPTION
- `Task.continuation` had a race condition where, if the cancellation occurred just before the start of the continuation then the body of the continuation may have still ran.
- As the cancellation previously only cancelled the continuation task after it was created, it couldn't handle the case when the task hadn't been created yet.
- Fix that, and add a test for it too!