### PR TITLE
Stricter Swiftlint

### DIFF
--- a/Vault/.swiftlint.yml
+++ b/Vault/.swiftlint.yml
@@ -3,22 +3,11 @@ indentation: 4
 excluded:
   - .build
 
-only_rules:
-  - colon
+opt_in_rules:
   - fatal_error_message
   - implicitly_unwrapped_optional
-  - legacy_cggeometry_functions
-  - legacy_constant
-  - legacy_constructor
-  - legacy_nsgeometry_functions
   - operator_usage_whitespace
-  - return_arrow_whitespace
-  - trailing_newline
-  - unused_optional_binding
-  - vertical_whitespace
-  - void_return
   - unowned_variable_capture
-  - custom_rules
   - no_coreData
   - no_objcMembers
   - no_nsLocalizedString
@@ -26,6 +15,25 @@ only_rules:
   - no_direct_standard_out_logs
   - no_unchecked_sendable
   - no_preconcurrency
+
+# Some are dumb, some are broken.
+# Broken ones are commented.
+disabled_rules:
+  - identifier_name
+  - nesting
+  - trailing_comma
+  - line_length
+  - large_tuple
+  - type_name
+  - type_body_length
+  - file_length
+  - todo
+  - function_body_length
+  - cyclomatic_complexity
+  - blanket_disable_command
+  - opening_brace # incompat with swiftformat
+  - closure_parameter_position # incompat with swiftformat
+  - void_function_in_ternary # broken, sees inits as void functions
 
 colon:
   apply_to_dictionaries: false

--- a/Vault/Sources/FoundationExtensions/Atomic/Atomic.swift
+++ b/Vault/Sources/FoundationExtensions/Atomic/Atomic.swift
@@ -1,8 +1,6 @@
 import Foundation
 import os
 
-// swiftlint:disable no_unchecked_sendable
-
 /// An atomic wrapper for any type, including primitive value types.
 /// use this to ensure accesses and modifications are thread safe.
 ///

--- a/Vault/Sources/FoundationExtensions/Key256Bit.swift
+++ b/Vault/Sources/FoundationExtensions/Key256Bit.swift
@@ -34,11 +34,13 @@ extension KeyData {
 
     public static func random() -> Self {
         // Force try: This is of the same length as the key, so it will not throw.
+        // swiftlint:disable:next force_try
         try! .init(data: .random(count: length))
     }
 
     public static func repeating(byte: UInt8) -> Self {
         // Force try: This is of the same length as the key, so it will not throw.
+        // swiftlint:disable:next force_try
         try! .init(data: Data(repeating: byte, count: length))
     }
 }

--- a/Vault/Sources/FoundationExtensions/SemVer.swift
+++ b/Vault/Sources/FoundationExtensions/SemVer.swift
@@ -62,6 +62,8 @@ extension SemVer: Comparable {
 
 extension SemVer: ExpressibleByStringLiteral {
     public init(stringLiteral value: String) {
+        // It's fine to crash on an invalid literal.
+        // swiftlint:disable:next force_try
         try! self.init(string: value)
     }
 }

--- a/Vault/Sources/VaultBackup/IntermediateEncoding/IntermediateEncodedVault.swift
+++ b/Vault/Sources/VaultBackup/IntermediateEncoding/IntermediateEncodedVault.swift
@@ -11,8 +11,4 @@ import Foundation
 struct IntermediateEncodedVault: Equatable {
     /// The raw encoded vault data.
     var data: Data
-
-    init(data: Data) {
-        self.data = data
-    }
 }

--- a/Vault/Sources/VaultFeed/Presentation/BackupImportFlowState.swift
+++ b/Vault/Sources/VaultFeed/Presentation/BackupImportFlowState.swift
@@ -20,11 +20,6 @@ struct BackupImportFlowState {
     let encryptedVault: EncryptedVault
     let encryptedVaultDecoder: any EncryptedVaultDecoder
 
-    init(encryptedVault: EncryptedVault, encryptedVaultDecoder: any EncryptedVaultDecoder) {
-        self.encryptedVault = encryptedVault
-        self.encryptedVaultDecoder = encryptedVaultDecoder
-    }
-
     /// There was a password provided, handle the state.
     func passwordProvided(password: DerivedEncryptionKey?) -> Action {
         guard let password else { return .promptForDifferentPassword }

--- a/Vault/Sources/VaultFeed/Presentation/OTPCode/OTPCodeDetailViewModel.swift
+++ b/Vault/Sources/VaultFeed/Presentation/OTPCode/OTPCodeDetailViewModel.swift
@@ -78,7 +78,7 @@ public final class OTPCodeDetailViewModel: DetailViewModel {
     public var showsKeyEditingFields: Bool {
         switch mode {
         case .creating(.none): true
-        case .creating(.some(_)): false
+        case .creating(.some): false
         case .editing: false
         }
     }

--- a/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedVaultTagEncoder.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedVaultTagEncoder.swift
@@ -2,8 +2,6 @@ import Foundation
 import SwiftData
 
 struct PersistedVaultTagEncoder {
-    init() {}
-
     func encode(tag: VaultItemTag.Write, writeUpdateContext: VaultItemTag.WriteUpdateContext) -> PersistedVaultTag {
         PersistedVaultTag(
             id: writeUpdateContext.id.id,

--- a/Vault/Sources/VaultiOS/Views/Feed/Previews/HOTPPreviewViewFactory.swift
+++ b/Vault/Sources/VaultiOS/Views/Feed/Previews/HOTPPreviewViewFactory.swift
@@ -15,7 +15,6 @@ protocol HOTPPreviewViewFactory {
 }
 
 struct HOTPPreviewViewFactoryImpl: HOTPPreviewViewFactory {
-    init() {}
     func makeHOTPView(
         viewModel: OTPCodePreviewViewModel,
         incrementer: OTPCodeIncrementerViewModel,

--- a/Vault/Sources/VaultiOS/Views/Feed/Previews/SecureNotePreviewViewFactory.swift
+++ b/Vault/Sources/VaultiOS/Views/Feed/Previews/SecureNotePreviewViewFactory.swift
@@ -10,7 +10,6 @@ protocol SecureNotePreviewViewFactory {
 }
 
 struct SecureNotePreviewViewFactoryImpl: SecureNotePreviewViewFactory {
-    init() {}
     func makeSecureNoteView(
         viewModel: SecureNotePreviewViewModel,
         behaviour: VaultItemViewBehaviour

--- a/Vault/Sources/VaultiOS/Views/Feed/Previews/TOTPPreviewViewFactory.swift
+++ b/Vault/Sources/VaultiOS/Views/Feed/Previews/TOTPPreviewViewFactory.swift
@@ -16,7 +16,6 @@ protocol TOTPPreviewViewFactory {
 }
 
 struct TOTPPreviewViewFactoryImpl: TOTPPreviewViewFactory {
-    init() {}
     func makeTOTPView(
         viewModel: OTPCodePreviewViewModel,
         periodState: OTPCodeTimerPeriodState,

--- a/Vault/Sources/VaultiOS/Views/General/ProminentButtonModifier.swift
+++ b/Vault/Sources/VaultiOS/Views/General/ProminentButtonModifier.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 /// Makes a button prominent with a standard background color and border.
 struct ProminentButtonModifier: ViewModifier {
-    init() {}
     func body(content: Content) -> some View {
         content
             .font(.callout)

--- a/Vault/Tests/FoundationExtensionsTests/PendingValueTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/PendingValueTests.swift
@@ -154,7 +154,7 @@ final class PendingValueTests: XCTestCase {
 
         do {
             _ = try await sut.awaitValue()
-            XCTFail()
+            XCTFail("Expected error to be thrown")
         } catch TestError.testCase2 {
             XCTAssert(true)
         } catch {

--- a/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNotePreviewViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNotePreviewViewModelTests.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 import TestHelpers
 import VaultFeed

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
@@ -1212,7 +1212,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
         let id1 = try await sut.insert(item: note)
         do {
             try await sut.incrementCounter(id: id1)
-            XCTFail()
+            XCTFail("Expected error")
         } catch {
             // expected
         }
@@ -1228,8 +1228,7 @@ final class PersistedLocalVaultStoreTests: XCTestCase {
         let item = try XCTUnwrap(all.items.first)
         switch item.item.otpCode?.type {
         case let .hotp(counter): XCTAssertEqual(counter, 13)
-        case .totp: XCTFail()
-        case nil: XCTFail()
+        default: XCTFail("Expected hotp")
         }
     }
 

--- a/Vault/Tests/VaultiOSTests/GenericVaultItemPreviewViewGeneratorTests.swift
+++ b/Vault/Tests/VaultiOSTests/GenericVaultItemPreviewViewGeneratorTests.swift
@@ -257,13 +257,13 @@ private class HOTPGeneratorMock: VaultItemPreviewViewGenerator, VaultItemPreview
         calledMethods.append(#function)
     }
 
-    var previewActionForVaultItemValue: VaultItemPreviewAction? = nil
+    var previewActionForVaultItemValue: VaultItemPreviewAction?
     func previewActionForVaultItem(id _: Identifier<VaultItem>) -> VaultItemPreviewAction? {
         calledMethods.append(#function)
         return previewActionForVaultItemValue
     }
 
-    var textToCopyForVaultItemValue: String? = nil
+    var textToCopyForVaultItemValue: String?
     func textToCopyForVaultItem(id _: Identifier<VaultItem>) -> String? {
         calledMethods.append(#function)
         return textToCopyForVaultItemValue
@@ -295,13 +295,13 @@ private class TOTPGeneratorMock: VaultItemPreviewViewGenerator, VaultItemPreview
         calledMethods.append(#function)
     }
 
-    var previewActionForVaultItemValue: VaultItemPreviewAction? = nil
+    var previewActionForVaultItemValue: VaultItemPreviewAction?
     func previewActionForVaultItem(id _: Identifier<VaultItem>) -> VaultItemPreviewAction? {
         calledMethods.append(#function)
         return previewActionForVaultItemValue
     }
 
-    var textToCopyForVaultItemValue: String? = nil
+    var textToCopyForVaultItemValue: String?
     func textToCopyForVaultItem(id _: Identifier<VaultItem>) -> String? {
         calledMethods.append(#function)
         return textToCopyForVaultItemValue
@@ -333,13 +333,13 @@ private class SecureNoteGeneratorMock: VaultItemPreviewViewGenerator, VaultItemP
         calledMethods.append(#function)
     }
 
-    var previewActionForVaultItemValue: VaultItemPreviewAction? = nil
+    var previewActionForVaultItemValue: VaultItemPreviewAction?
     func previewActionForVaultItem(id _: Identifier<VaultItem>) -> VaultItemPreviewAction? {
         calledMethods.append(#function)
         return previewActionForVaultItemValue
     }
 
-    var textToCopyForVaultItemValue: String? = nil
+    var textToCopyForVaultItemValue: String?
     func textToCopyForVaultItem(id _: Identifier<VaultItem>) -> String? {
         calledMethods.append(#function)
         return textToCopyForVaultItemValue


### PR DESCRIPTION
- Uses default rules now (disabling incompatible or dumb rules)
  - Using `only_rules` it wasn't easy to see what we were disable vs. the default rules, but now that's explict.
- Still opt-in to rules that we want, including custom rules