### PR TITLE
Fix botched compile of speedtest

### DIFF
--- a/Vault/Sources/VaultKeygenSpeedtest/Speedtest.swift
+++ b/Vault/Sources/VaultKeygenSpeedtest/Speedtest.swift
@@ -36,9 +36,7 @@ func benchmark(keyDeriver: some KeyDeriver, description: String) throws {
 func buildConfigString() -> String {
     #if DEBUG
     return "⚠️ DEBUG"
-    #elseif RELEASE
-    return "✅ RELEASE"
     #else
-    #error("💀 Unknown or unsupported build configuration.")
+    return "✅ RELEASE"
     #endif
 }


### PR DESCRIPTION
- Fixes a botched check in the speedtest binary.
- If in `RELEASE`, there will simply be no `DEBUG` flag set.