### PR TITLE
Don't compile error on running in DEBUG

### DIFF
--- a/Vault/Sources/VaultKeygenSpeedtest/Speedtest.swift
+++ b/Vault/Sources/VaultKeygenSpeedtest/Speedtest.swift
@@ -31,7 +31,7 @@ func benchmark(keyDeriver: some KeyDeriver, description: String) throws {
 
 func buildConfigString() -> String {
     #if DEBUG
-    #error("⚠️ DEBUG configuration: this script should be run in release mode")
+    return "⚠️ DEBUG"
     #else
     return "✅ RELEASE"
     #endif


### PR DESCRIPTION
The build tests run in CI, and this runs in DEBUG. Just warn with log message.