### PR TITLE
Create XCTest exceptions rather than using allowlist

### DIFF
--- a/Vault/.swiftlint.yml
+++ b/Vault/.swiftlint.yml
@@ -84,7 +84,7 @@ custom_rules:
     message: "Is there a library that supports concurrency instead? We want to be thread safe, if at all possible! Please provide a description if this is unavoidable."
     severity: error
   no_xctest:
-    included: "Tests/(FoundationExtensionsTests|ImageToolsTests|CryptoEngineTests)/*"
+    excluded: "(Tests/(CryptoDocumentExporterSnapshotTests|CryptoDocumentExporterTests|VaultBackupTests|VaultCoreTests|VaultFeedTests|VaultiOSTests|VaultSettingsTests)|Sources/TestHelpers)/*"
     name: "XCTest is not allowed in this target."
     regex: "import XCTest"
     match_kinds:


### PR DESCRIPTION
- This ensures that new test targets use Swift Testing by default