### PR TITLE
Migrate `DetailEditStateTests` to Swift Testing

### DIFF
--- a/Vault/Tests/VaultFeedTests/Presentation/DetailEditStateTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/DetailEditStateTests.swift
@@ -170,7 +170,7 @@ struct DetailEditStateTests {
         let sut = makeSUT()
 
         try await confirmation(timeout: .milliseconds(200), expectedCount: 0) { confirmation in
-            try await sut.deleteItem {
+            try? await sut.deleteItem {
                 throw TestError()
             } finished: {
                 confirmation.confirm()


### PR DESCRIPTION
- Initial migration of model types that use `@MainActor`
  - There's a few issues in the Swift Testing library surrounding global actors ([see here](https://github.com/swiftlang/swift-testing/pull/624)), so we will likely wait for Swift 6.1 before migrating most of the code in `VaultFeedTests` and `VaultiOSTests`, the only 2 packages left that have XCTests in them.
- Resolves #330  