### PR TITLE
Obfuscate TOTP codes when app is inactive

### DIFF
--- a/Vault/Sources/VaultFeed/Presentation/OTPCode/OTPCodeState.swift
+++ b/Vault/Sources/VaultFeed/Presentation/OTPCode/OTPCodeState.swift
@@ -3,12 +3,17 @@ import Foundation
 public enum OTPCodeState: Equatable {
     case notReady
     case finished
-    case obfuscated
+    case obfuscated(ObfuscationReason)
     case visible(String)
     case error(PresentationError, digits: Int)
 }
 
 extension OTPCodeState {
+    public enum ObfuscationReason: Equatable {
+        case privacy
+        case expiry
+    }
+
     public var allowsNextCodeToBeGenerated: Bool {
         switch self {
         case .visible, .obfuscated:

--- a/Vault/Sources/VaultFeed/Presentation/Previews/OTPCodePreviewViewModel.swift
+++ b/Vault/Sources/VaultFeed/Presentation/Previews/OTPCodePreviewViewModel.swift
@@ -70,7 +70,12 @@ public final class OTPCodePreviewViewModel {
         self.code = code
     }
 
-    public func hideCodeUntilNextUpdate() {
-        code = .obfuscated
+    public func obfuscateCodeForPrivacy() {
+        code = .obfuscated(.privacy)
+    }
+
+    /// Indicates that the code has expired
+    public func codeExpired() {
+        code = .obfuscated(.expiry)
     }
 }

--- a/Vault/Sources/VaultiOS/Views/Previews/OTP/HOTPPreviewViewGenerator.swift
+++ b/Vault/Sources/VaultiOS/Views/Previews/OTP/HOTPPreviewViewGenerator.swift
@@ -34,7 +34,7 @@ final class HOTPPreviewViewGenerator<Factory: HOTPPreviewViewFactory>: VaultItem
 
     func scenePhaseDidChange(to scene: ScenePhase) {
         if scene == .background {
-            hideAllCodesUntilNextUpdate()
+            markAllCodesAsExpired()
         }
     }
 
@@ -44,9 +44,9 @@ final class HOTPPreviewViewGenerator<Factory: HOTPPreviewViewFactory>: VaultItem
 }
 
 extension HOTPPreviewViewGenerator {
-    func hideAllCodesUntilNextUpdate() {
+    func markAllCodesAsExpired() {
         for viewModel in previewViewModelCache.values {
-            viewModel.hideCodeUntilNextUpdate()
+            viewModel.codeExpired()
         }
     }
 }
@@ -117,7 +117,7 @@ extension HOTPPreviewViewGenerator: VaultItemCache {
                 color: metadata.color ?? .default,
                 codePublisher: makeCodePublisher(id: metadata.id, code: code)
             )
-            viewModel.hideCodeUntilNextUpdate()
+            viewModel.codeExpired()
             return viewModel
         }
     }

--- a/Vault/Sources/VaultiOS/Views/Previews/OTP/TOTPPreviewViewGenerator.swift
+++ b/Vault/Sources/VaultiOS/Views/Previews/OTP/TOTPPreviewViewGenerator.swift
@@ -46,7 +46,7 @@ final class TOTPPreviewViewGenerator<Factory: TOTPPreviewViewFactory>: VaultItem
     func scenePhaseDidChange(to scene: ScenePhase) {
         switch scene {
         case .background, .inactive:
-            hideAllPreviews()
+            hideAllPreviewsForPrivacy()
             cancelAllTimers()
         case .active:
             recalculateAllTimers()
@@ -73,9 +73,9 @@ extension TOTPPreviewViewGenerator {
         }
     }
 
-    func hideAllPreviews() {
+    func hideAllPreviewsForPrivacy() {
         for viewModel in viewModelCache.values {
-            viewModel.hideCodeUntilNextUpdate()
+            viewModel.obfuscateCodeForPrivacy()
         }
     }
 }

--- a/Vault/Sources/VaultiOS/Views/TimerBar/CodeStateTimerBarView.swift
+++ b/Vault/Sources/VaultiOS/Views/TimerBar/CodeStateTimerBarView.swift
@@ -48,11 +48,17 @@ struct CodeStateTimerBarView<Timer: View>: View {
         case let .editingState(message):
             message
         case .normal:
-            if case let .error(err, _) = codeState {
-                err.userTitle
-            } else if case .obfuscated = codeState {
-                localized(key: "code.updateRequired")
-            } else {
+            switch codeState {
+            case let .obfuscated(obfuscationReason):
+                switch obfuscationReason {
+                case .expiry:
+                    localized(key: "code.updateRequired")
+                case .privacy:
+                    nil
+                }
+            case let .error(presentationError, _):
+                presentationError.userTitle
+            case .visible, .notReady, .finished:
                 nil
             }
         }

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodePreviewViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodePreviewViewModelTests.swift
@@ -52,14 +52,25 @@ final class OTPCodePreviewViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_hideCodeUntilNextUpdate_obfuscatesCode() async throws {
+    func test_codeExpired_obfuscatesCode() async throws {
         let (_, sut) = makeSUT()
 
         await expectSingleMutation(observable: sut, keyPath: \.code) {
-            sut.hideCodeUntilNextUpdate()
+            sut.codeExpired()
         }
 
-        XCTAssertEqual(sut.code, .obfuscated)
+        XCTAssertEqual(sut.code, .obfuscated(.expiry))
+    }
+
+    @MainActor
+    func test_obfuscateCodeForPrivacy_obfuscatesCode() async throws {
+        let (_, sut) = makeSUT()
+
+        await expectSingleMutation(observable: sut, keyPath: \.code) {
+            sut.obfuscateCodeForPrivacy()
+        }
+
+        XCTAssertEqual(sut.code, .obfuscated(.privacy))
     }
 
     @MainActor

--- a/Vault/Tests/VaultiOSTests/HOTPPreviewViewGeneratorTests.swift
+++ b/Vault/Tests/VaultiOSTests/HOTPPreviewViewGeneratorTests.swift
@@ -35,7 +35,7 @@ final class HOTPPreviewViewGeneratorTests: XCTestCase {
         )
 
         XCTAssertEqual(viewModels.count, 2)
-        XCTAssertTrue(viewModels.allSatisfy { $0.code == .obfuscated })
+        XCTAssertTrue(viewModels.allSatisfy { $0.code == .obfuscated(.expiry) })
     }
 
     @MainActor
@@ -130,11 +130,11 @@ final class HOTPPreviewViewGeneratorTests: XCTestCase {
     }
 
     @MainActor
-    func test_hideAllCodesUntilNextUpdate_marksCachedViewModelsAsObfuscated() {
+    func test_markAllCodesAsExpired_marksCachedViewModelsAsObfuscated() {
         let (sut, _, factory) = makeSUT()
 
         expectHidesAllCodesUntilNextUpdate(sut: sut, factory: factory) {
-            sut.hideAllCodesUntilNextUpdate()
+            sut.markAllCodesAsExpired()
         }
     }
 
@@ -199,11 +199,11 @@ extension HOTPPreviewViewGeneratorTests {
             viewModel.update(code: .visible("1234"))
         }
 
-        XCTAssertTrue(viewModels.allSatisfy { $0.code != .obfuscated })
+        XCTAssertTrue(viewModels.allSatisfy { $0.code != .obfuscated(.expiry) })
 
         action()
 
-        XCTAssertTrue(viewModels.allSatisfy { $0.code == .obfuscated })
+        XCTAssertTrue(viewModels.allSatisfy { $0.code == .obfuscated(.expiry) })
     }
 
     @MainActor

--- a/Vault/Tests/VaultiOSTests/OTPCodeTextViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/OTPCodeTextViewSnapshotTests.swift
@@ -29,7 +29,7 @@ final class OTPCodeTextViewSnapshotTests: XCTestCase {
 
     @MainActor
     func test_obfuscated_staysOnSingleLine() {
-        let view = makeSUT(codeState: .obfuscated)
+        let view = makeSUT(codeState: .obfuscated(.expiry))
 
         assertSnapshot(of: view, as: .image)
     }


### PR DESCRIPTION
- We should respect iOS documentation and cancel timers etc. when the application becomes `inactive`.
- However, inactive does not necessarily mean not visible to the user. We also want to make sure that codes cannot be snooped when the application is not in the foreground.
- Now, when the application enters the background, TOTP codes will be hidden (including the remaining time) for additional privacy and to avoid potential issues related to outdated timers.