### PR TITLE
Fix HOTP code not hiding when scene inactive

### DIFF
--- a/Vault/Sources/VaultFeed/Presentation/Previews/OTPCodePreviewViewModel.swift
+++ b/Vault/Sources/VaultFeed/Presentation/Previews/OTPCodePreviewViewModel.swift
@@ -10,6 +10,7 @@ public final class OTPCodePreviewViewModel {
     public let issuer: String
     public let color: VaultItemColor
     public private(set) var code: OTPCodeState = .notReady
+    private var obfuscatedCode: OTPCodeState?
 
     public var visibleIssuer: String {
         if issuer.isNotEmpty {
@@ -71,7 +72,18 @@ public final class OTPCodePreviewViewModel {
     }
 
     public func obfuscateCodeForPrivacy() {
+        obfuscatedCode = code
         code = .obfuscated(.privacy)
+    }
+
+    /// If the code was obfuscated for privacy, this removes the obfuscation.
+    ///
+    /// Has no effect if the code was not hidden for a privacy.
+    public func unobfuscateCodeForPrivacy() {
+        if let obfuscatedCode, case .obfuscated(.privacy) = code {
+            code = obfuscatedCode
+        }
+        obfuscatedCode = nil
     }
 
     /// Indicates that the code has expired

--- a/Vault/Sources/VaultiOS/Views/Previews/OTP/HOTPPreviewViewGenerator.swift
+++ b/Vault/Sources/VaultiOS/Views/Previews/OTP/HOTPPreviewViewGenerator.swift
@@ -35,7 +35,7 @@ final class HOTPPreviewViewGenerator<Factory: HOTPPreviewViewFactory>: VaultItem
     func scenePhaseDidChange(to scene: ScenePhase) {
         switch scene {
         case .active:
-            break
+            unhideAllPreviewsForPrivacy()
         case .inactive:
             hideAllPreviewsForPrivacy()
         case .background:
@@ -60,6 +60,12 @@ extension HOTPPreviewViewGenerator {
     func hideAllPreviewsForPrivacy() {
         for viewModel in previewViewModelCache.values {
             viewModel.obfuscateCodeForPrivacy()
+        }
+    }
+
+    func unhideAllPreviewsForPrivacy() {
+        for viewModel in previewViewModelCache.values {
+            viewModel.unobfuscateCodeForPrivacy()
         }
     }
 }

--- a/Vault/Tests/VaultiOSTests/HOTPPreviewViewGeneratorTests.swift
+++ b/Vault/Tests/VaultiOSTests/HOTPPreviewViewGeneratorTests.swift
@@ -157,6 +157,15 @@ final class HOTPPreviewViewGeneratorTests: XCTestCase {
     }
 
     @MainActor
+    func test_scenePhaseDidChange_activeUnobfuscatesPrivacyHiddenViews() {
+        let (sut, _, factory) = makeSUT()
+
+        expectUnobfuscatesAllCodesForPrivacy(sut: sut, factory: factory) {
+            sut.scenePhaseDidChange(to: .active)
+        }
+    }
+
+    @MainActor
     func test_invalidateCache_removesCodeSpecificObjectsFromCache() async throws {
         let (sut, _, _) = makeSUT()
 
@@ -190,6 +199,29 @@ extension HOTPPreviewViewGeneratorTests {
     private func anyHOTPCode() -> HOTPAuthCode {
         let codeData = OTPAuthCodeData(secret: .empty(), accountName: "Test")
         return .init(data: codeData)
+    }
+
+    @MainActor
+    private func expectUnobfuscatesAllCodesForPrivacy(
+        sut: SUT,
+        factory: HOTPPreviewViewFactoryMock,
+        when action: () -> Void
+    ) {
+        let viewModels = collectCodePreviewViewModels(
+            sut: sut,
+            factory: factory,
+            ids: [Identifier<VaultItem>(), Identifier<VaultItem>()]
+        )
+
+        viewModels[0].update(code: .visible("1234"))
+        viewModels[1].update(code: .visible("5678"))
+        viewModels[0].obfuscateCodeForPrivacy()
+        viewModels[1].update(code: .obfuscated(.expiry))
+
+        action()
+
+        XCTAssertEqual(viewModels[0].code, .visible("1234"))
+        XCTAssertEqual(viewModels[1].code, .obfuscated(.expiry))
     }
 
     @MainActor


### PR DESCRIPTION
- Resolves #352
- Hide HOTP codes when the scene becomes inactive, matching behaviour of TOTP codes
- When the scene becomes active again, the code is reshown.
- When the scene enters the background, HOTP codes are still expired, matching the behaviour of Google Authenticator.