### PR TITLE
Remove swiftlint ignore annoation around sending

### DIFF
--- a/Vault/Sources/TestHelpers/SwiftTesting/Publisher+Testing.swift
+++ b/Vault/Sources/TestHelpers/SwiftTesting/Publisher+Testing.swift
@@ -29,9 +29,7 @@ extension Publisher where Output: Equatable, Output: Sendable {
         firstValues: [Output],
         timeout: Duration = .seconds(1),
         sourceLocation: SourceLocation = .__here(),
-        // swiftlint:disable all
         when actions: sending @escaping () async throws -> Void
-        // swiftlint:enable all
     ) async throws {
         var cancellable: AnyCancellable?
         defer { cancellable?.cancel() }


### PR DESCRIPTION
- We still get parser errors as swiftlint isn't yet updated to the Swift 6 syntax, but let's just ignore the errors for now and we will just update as soon as possible. 
- It's not worth going directly to `main` for a release, and also we want to make sure we're in sync with the tooling that gives us warnings in Xcode (SwiftLintPlugins).