### PR TITLE
Improve reliability of observation tracking test methods

### DIFF
--- a/Vault/Sources/TestHelpers/XCTest/XCTestCase+Observable.swift
+++ b/Vault/Sources/TestHelpers/XCTest/XCTestCase+Observable.swift
@@ -17,6 +17,7 @@ extension XCTestCase {
         }
 
         try await action()
+        await Task.yield()
 
         await fulfillment(of: [exp], timeout: 1.0)
     }
@@ -37,6 +38,7 @@ extension XCTestCase {
         }
 
         try await action()
+        await Task.yield()
 
         await fulfillment(of: [exp], timeout: timeout)
     }


### PR DESCRIPTION
- Resolves #364 
- Allowing the task to yield should allow more time for the observations