### PR TITLE
Replace all test uses of NSError with Swift-native TestError

### DIFF
--- a/Vault/Tests/VaultFeedTests/Authentication/DeviceAuthenticationServiceTests.swift
+++ b/Vault/Tests/VaultFeedTests/Authentication/DeviceAuthenticationServiceTests.swift
@@ -98,7 +98,7 @@ final class DeviceAuthenticationServiceTests: XCTestCase {
             canAuthenicateWithPasscode: false,
             canAuthenticateWithBiometrics: true
         )
-        policy.authenticateWithBiometricsHandler = { _ in throw anyNSError() }
+        policy.authenticateWithBiometricsHandler = { _ in throw TestError() }
         let sut = makeSUT(policy: policy)
 
         await XCTAssertThrowsError(try await sut.authenticate(reason: "reason"))
@@ -142,7 +142,7 @@ final class DeviceAuthenticationServiceTests: XCTestCase {
             canAuthenicateWithPasscode: true,
             canAuthenticateWithBiometrics: false
         )
-        policy.authenticateWithPasscodeHandler = { _ in throw anyNSError() }
+        policy.authenticateWithPasscodeHandler = { _ in throw TestError() }
         let sut = makeSUT(policy: policy)
 
         await XCTAssertThrowsError(try await sut.authenticate(reason: "reason"))

--- a/Vault/Tests/VaultFeedTests/Helpers/SharedTestHelpers.swift
+++ b/Vault/Tests/VaultFeedTests/Helpers/SharedTestHelpers.swift
@@ -261,10 +261,6 @@ func hotpRfcSecretData() -> Data {
 
 // MARK: - Misc
 
-func anyNSError() -> NSError {
-    NSError(domain: "any", code: 100)
-}
-
 struct TestError: Error {}
 
 extension UserDefaults {

--- a/Vault/Tests/VaultFeedTests/Presentation/DetailEditStateTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/DetailEditStateTests.swift
@@ -80,7 +80,7 @@ struct DetailEditStateTests {
         let sut = makeSUT()
         sut.startEditing()
 
-        try? await sut.saveChanges { throw anyNSError() }
+        try? await sut.saveChanges { throw TestError() }
 
         #expect(sut.isInEditMode)
     }

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailViewModelTests.swift
@@ -161,7 +161,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
     func test_saveChanges_creatingSendsErrorIfSaveError() async throws {
         let editor = OTPCodeDetailEditorMock()
         editor.createCodeHandler = { _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTCreating(editor: editor)
 
@@ -177,7 +177,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
     func test_saveChanges_creatingSetsSavingToFalseAfterSaveError() async throws {
         let editor = OTPCodeDetailEditorMock()
         editor.createCodeHandler = { _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTCreating(editor: editor)
 
@@ -200,7 +200,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
     func test_saveChanges_editingSetsSavingToFalseAfterSaveError() async throws {
         let editor = OTPCodeDetailEditorMock()
         editor.updateCodeHandler = { _, _, _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTEditing(editor: editor)
 
@@ -213,7 +213,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
     func test_saveChanges_editingDoesNotPersistEditingModelIfSaveFailed() async throws {
         let editor = OTPCodeDetailEditorMock()
         editor.updateCodeHandler = { _, _, _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTEditing(editor: editor)
         makeDirty(sut: sut)
@@ -227,7 +227,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
     func test_saveChanges_editingSendsErrorIfSaveError() async throws {
         let editor = OTPCodeDetailEditorMock()
         editor.updateCodeHandler = { _, _, _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTEditing(editor: editor)
 
@@ -274,7 +274,7 @@ final class OTPCodeDetailViewModelTests: XCTestCase {
     func test_deleteCode_editingSendsErrorIfDeleteError() async throws {
         let editor = OTPCodeDetailEditorMock()
         editor.deleteCodeHandler = { _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTEditing(editor: editor)
 

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodePreviewViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodePreviewViewModelTests.swift
@@ -55,7 +55,7 @@ final class OTPCodePreviewViewModelTests: XCTestCase {
         let (codePublisher, sut) = makeSUT()
 
         await expectSingleMutation(observable: sut, keyPath: \.code) {
-            codePublisher.subject.send(completion: .failure(anyNSError()))
+            codePublisher.subject.send(completion: .failure(TestError()))
         }
 
         switch sut.code {

--- a/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailViewModelTests.swift
@@ -114,7 +114,7 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
     func test_saveChanges_creatingSendsErrorIfSaveError() async throws {
         let editor = SecureNoteDetailEditorMock()
         editor.createNoteHandler = { _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTCreating(editor: editor)
 
@@ -130,7 +130,7 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
     func test_saveChanges_creatingSetsSavingToFalseAfterSaveError() async throws {
         let editor = SecureNoteDetailEditorMock()
         editor.createNoteHandler = { _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTCreating(editor: editor)
 
@@ -168,7 +168,7 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
     func test_saveChanges_setsSavingToFalseAfterSaveError() async throws {
         let editor = SecureNoteDetailEditorMock()
         editor.updateNoteHandler = { _, _, _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTEditing(editor: editor)
 
@@ -181,7 +181,7 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
     func test_saveChanges_doesNotPersistEditingModelIfSaveFailed() async throws {
         let editor = SecureNoteDetailEditorMock()
         editor.updateNoteHandler = { _, _, _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTEditing(editor: editor)
         makeDirty(sut: sut)
@@ -195,7 +195,7 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
     func test_saveChanges_sendsErrorIfSaveError() async throws {
         let editor = SecureNoteDetailEditorMock()
         editor.updateNoteHandler = { _, _, _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTEditing(editor: editor)
 
@@ -242,7 +242,7 @@ final class SecureNoteDetailViewModelTests: XCTestCase {
     func test_deleteNote_sendsErrorIfDeleteError() async throws {
         let editor = SecureNoteDetailEditorMock()
         editor.deleteNoteHandler = { _ in
-            throw anyNSError()
+            throw TestError()
         }
         let sut = makeSUTEditing(editor: editor)
 

--- a/Vault/Tests/VaultFeedTests/Presentation/VaultDataModelEditorAdapterTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/VaultDataModelEditorAdapterTests.swift
@@ -61,7 +61,7 @@ final class VaultDataModelEditorAdapterTests: XCTestCase {
 
     @MainActor
     func test_createCode_propagatesFailureOnError() async throws {
-        let store = VaultStoreErroring(error: anyNSError())
+        let store = VaultStoreErroring(error: TestError())
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: store)
         let sut = makeSUT(dataModel: dataModel)
 
@@ -252,7 +252,7 @@ final class VaultDataModelEditorAdapterTests: XCTestCase {
 
     @MainActor
     func test_updateNote_propagatesFailureOnError() async {
-        let store = VaultStoreErroring(error: anyNSError())
+        let store = VaultStoreErroring(error: TestError())
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: store)
         let sut = makeSUT(dataModel: dataModel)
 
@@ -281,7 +281,7 @@ final class VaultDataModelEditorAdapterTests: XCTestCase {
 
     @MainActor
     func test_deleteNote_propagatesFailureOnError() async {
-        let store = VaultStoreErroring(error: anyNSError())
+        let store = VaultStoreErroring(error: TestError())
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: store)
         let sut = makeSUT(dataModel: dataModel)
 

--- a/Vault/Tests/VaultFeedTests/Storage/BackupPasswordStoreImplTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/BackupPasswordStoreImplTests.swift
@@ -18,7 +18,7 @@ final class BackupPasswordStoreImplTests: XCTestCase {
     func test_fetchPassword_fetchErrorRethrowsError() async throws {
         let storage = SecureStorageMock()
         let sut = makeSUT(secureStorage: storage)
-        storage.retrieveHandler = { _ in throw anyNSError() }
+        storage.retrieveHandler = { _ in throw TestError() }
 
         await XCTAssertThrowsError(try await sut.fetchPassword())
     }
@@ -39,7 +39,7 @@ final class BackupPasswordStoreImplTests: XCTestCase {
         let storage = SecureStorageMock()
         let sut = makeSUT(secureStorage: storage)
         storage.storeHandler = { _, _ in
-            throw anyNSError()
+            throw TestError()
         }
 
         let password = anyBackupPassword()

--- a/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
@@ -221,7 +221,7 @@ final class VaultDataModelTests: XCTestCase {
 
     @MainActor
     func test_reloadItems_presentsErrorOnFailure() async {
-        let store = VaultStoreErroring(error: anyNSError())
+        let store = VaultStoreErroring(error: TestError())
         let sut = makeSUT(vaultStore: store)
 
         await sut.reloadData()

--- a/Vault/Tests/VaultiOSTests/Helpers/SharedTestHelpers.swift
+++ b/Vault/Tests/VaultiOSTests/Helpers/SharedTestHelpers.swift
@@ -113,10 +113,6 @@ extension VaultItemPreviewViewGeneratorMock {
     }
 }
 
-func anyNSError() -> NSError {
-    NSError(domain: "any", code: 100)
-}
-
 func uniqueCode() -> OTPAuthCode {
     let randomData = Data.random(count: 50)
     return OTPAuthCode(


### PR DESCRIPTION
- More consistent, less legacy