### PR TITLE
Share timer publishers for efficiency

### DIFF
--- a/Vault/Sources/VaultFeed/Presentation/OTPCode/OTPCodeTimerUpdater.swift
+++ b/Vault/Sources/VaultFeed/Presentation/OTPCode/OTPCodeTimerUpdater.swift
@@ -35,11 +35,14 @@ public final class OTPCodeTimerUpdaterImpl: OTPCodeTimerUpdater, Sendable {
     /// Publishes when there is a change to the timer that needs to be reflected in the view.
     public var timerUpdatedPublisher: AnyPublisher<OTPCodeTimerState, Never> {
         timerStateSubject
+            .share()
             .eraseToAnyPublisher()
     }
 
     public var timerFiredPublisher: AnyPublisher<Void, Never> {
-        timerFiredSubject.eraseToAnyPublisher()
+        timerFiredSubject
+            .share()
+            .eraseToAnyPublisher()
     }
 
     /// Forces the timer to recalculate it's current state and republish.


### PR DESCRIPTION
- Resolves #373 
- By making these multicast, the intention is to reduce overhead as many timer bars, code publishers etc. all subscribe/adapt these publisher pipelines