### PR TITLE
Remove unsaved changes warning for backups

### DIFF
--- a/Vault/Sources/VaultiOS/Views/Backup/BackupView.swift
+++ b/Vault/Sources/VaultiOS/Views/Backup/BackupView.swift
@@ -120,8 +120,7 @@ struct BackupView: View {
         Section {
             if let password {
                 LastBackupSummaryView(
-                    lastBackup: dataModel.lastBackupEvent,
-                    currentHash: dataModel.currentPayloadHash
+                    lastBackup: dataModel.lastBackupEvent
                 )
 
                 Button {

--- a/Vault/Sources/VaultiOS/Views/Backup/LastBackupSummaryView.swift
+++ b/Vault/Sources/VaultiOS/Views/Backup/LastBackupSummaryView.swift
@@ -5,7 +5,6 @@ import VaultFeed
 
 struct LastBackupSummaryView: View {
     var lastBackup: VaultBackupEvent?
-    var currentHash: Digest<VaultApplicationPayload>.SHA256?
 
     var body: some View {
         VStack(alignment: .center, spacing: 4) {
@@ -18,28 +17,6 @@ struct LastBackupSummaryView: View {
                     .foregroundStyle(.primary)
                 Text(lastBackup.kind.localizedTitle)
                     .foregroundStyle(.secondary)
-
-                if let currentHash {
-                    if lastBackup.payloadHash == currentHash {
-                        HStack(alignment: .firstTextBaseline) {
-                            Image(systemName: "checkmark.circle.fill")
-                            Text("Latest changes backed up")
-                        }
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(.green)
-                        .textCase(.uppercase)
-                        .padding(.top, 8)
-                    } else {
-                        HStack(alignment: .firstTextBaseline) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                            Text("Recent changes have not been backed up")
-                        }
-                        .font(.caption2.weight(.medium))
-                        .foregroundStyle(.orange)
-                        .textCase(.uppercase)
-                        .padding(.top, 8)
-                    }
-                }
             } else {
                 Text("You haven't created a backup from this device and could be at risk of data loss.")
                     .multilineTextAlignment(.center)
@@ -77,12 +54,12 @@ struct LastBackupSummaryView: View {
             eventDate: Date(),
             kind: .exportedToPDF,
             payloadHash: .init(value: Data(hex: "ababa"))
-        ), currentHash: .init(value: Data()))
+        ))
         LastBackupSummaryView(lastBackup: VaultBackupEvent(
             backupDate: Date(),
             eventDate: Date(),
             kind: .exportedToPDF,
             payloadHash: .init(value: Data(hex: "ababa"))
-        ), currentHash: .init(value: Data(hex: "ababa")))
+        ))
     }
 }


### PR DESCRIPTION
- Resolves #393 
- Now that we have killphrases, this change could inadvertantly reveal to a bystander that the vault was modified. The user must be able to maintain full deniability.