### PR TITLE
Add FAQ entries for item encryption and device transfer

### DIFF
--- a/Vault/Sources/VaultSettings/Resources+FileBackedContent.swift
+++ b/Vault/Sources/VaultSettings/Resources+FileBackedContent.swift
@@ -21,6 +21,20 @@ public final class FAQBackupsSecurityFileContent: FileBackedContent {
     public init() {}
 }
 
+public final class FAQItemEncryptionFileContent: FileBackedContent {
+    public let fileName: String = "FAQ-Item-Encryption"
+    public let fileExtension: String = "md"
+
+    public init() {}
+}
+
+public final class FAQSyncDevicesFileContent: FileBackedContent {
+    public let fileName: String = "FAQ-Sync-Devices"
+    public let fileExtension: String = "md"
+
+    public init() {}
+}
+
 public struct PrivacyPolicyContent: FileBackedContent {
     public let fileName: String = "PrivacyPolicy"
     public let fileExtension: String = "md"

--- a/Vault/Sources/VaultSettings/Resources/en.lproj/FAQ-Item-Encryption.md
+++ b/Vault/Sources/VaultSettings/Resources/en.lproj/FAQ-Item-Encryption.md
@@ -1,0 +1,28 @@
+By default, items in your vault are stored on this device without an additional layer of encryption — they are protected by the security of the device itself.
+
+If you want extra protection for sensitive items, Vault lets you encrypt individual items with a password of your choice. This is independent from your backup password and from any other items in your vault.
+
+## How does the encryption work?
+
+When you set an encryption password on an item, it runs through a key derivation function (KDF) with some random salt that is used to generate a 256 bit key.
+This key is then used with AES-GCM to perform a symmetric encryption of that item's contents.
+
+The password is **never stored** anywhere on the device. Each time you want to view the item, you'll be asked to enter the password so the key can be re-derived and the contents decrypted in memory.
+
+This means the source of truth for an encrypted item is the password that you choose, so you should make this as strong as possible.
+The longer and more complex the better.
+
+## What if I forget the password?
+
+There is no recovery mechanism. If you forget the password for an encrypted item, that item is **permanently inaccessible** — not even you can recover it.
+
+This is the trade-off for strong encryption: it protects your data from everyone, including you, if the password is lost.
+
+## Is this the same as locking an item with Face ID?
+
+No — these are two separate features that can be used together.
+
+- **Per-item encryption** (this page) encrypts the item's contents with a password you choose. Without the password, the data cannot be read by anything.
+- **Per-item lock** uses your device's native security (Face ID, Touch ID, or device passcode) to gate access to the item in the app. The data itself is not re-encrypted — the device's own protections are used to keep it out of view.
+
+Use per-item encryption when you want the strongest possible protection. Use a per-item lock when you just want a quick prompt before viewing.

--- a/Vault/Sources/VaultSettings/Resources/en.lproj/FAQ-Sync-Devices.md
+++ b/Vault/Sources/VaultSettings/Resources/en.lproj/FAQ-Sync-Devices.md
@@ -1,0 +1,27 @@
+Vault does **not** automatically sync your items between devices, and this is by design.
+Keeping your data on a single device, under your control, is what allows Vault to make the privacy guarantees it does — nothing is ever uploaded to a server, and there is no account to compromise.
+
+To move items to another device, you create a backup on one device and restore it on the other.
+
+## Moving everything to a new device
+
+1. On your current device, create a backup from the Backups screen and choose a strong password.
+2. Get that backup file onto your new device. A few options:
+    - Save it to **iCloud Drive** (or any other cloud storage you trust) and open it on the new device via the Files app.
+    - Send it to yourself via **AirDrop**.
+    - Print the backup as a paper copy and **scan the QR code** on the new device.
+3. On the new device, open the backup from the Backups screen and enter the password you chose. Use **Import & Override** to replace anything already there with the backup's contents.
+
+## Can I automate this with iCloud Drive?
+
+Partially. Vault supports **automatic backups to iCloud Drive** — you point Vault at a folder in your iCloud Drive once, and it will keep a fresh backup there for you.
+
+This is **not sync**. It's still a backup-and-restore flow: your other device sees the backup file appear in iCloud Drive, and you import it from there. Items don't appear automatically and edits don't propagate.
+
+For most people this is still more friction than it's worth — it's usually easier to pick one device as the "primary" and keep the other as a backup destination only. But if you do want the two devices to stay roughly in step, auto-backup to iCloud Drive plus **Import & Merge** on the other device is the closest you can get. Merging keeps the most recent edit for each item, so it's safe in both directions.
+
+## Why isn't there a true sync option?
+
+True sync would mean either uploading your data to a server (even encrypted, this introduces a new attack surface and a new account for you to manage) or relying on a system like iCloud's CloudKit to silently move your data between devices.
+
+Vault deliberately avoids both. The backup-and-restore flow — even when iCloud Drive is doing the heavy lifting — keeps you in full control of when and where your data moves.

--- a/Vault/Sources/VaultiOS/Views/Settings/HelpView.swift
+++ b/Vault/Sources/VaultiOS/Views/Settings/HelpView.swift
@@ -8,6 +8,7 @@ struct HelpView: View {
     var body: some View {
         Form {
             generalSection
+            securitySection
             backupsSection
         }
         .navigationTitle(Text(viewModel.helpTitle))
@@ -25,6 +26,18 @@ struct HelpView: View {
         }
     }
 
+    private var securitySection: some View {
+        Section {
+            NavigationLink {
+                SettingsDocumentView(title: "Item Encryption", content: FAQItemEncryptionFileContent())
+            } label: {
+                Label("Can I encrypt individual items?", systemImage: "lock.shield.fill")
+            }
+        } header: {
+            Label("Security", systemImage: "lock.fill")
+        }
+    }
+
     private var backupsSection: some View {
         Section {
             NavigationLink {
@@ -37,6 +50,12 @@ struct HelpView: View {
                 SettingsDocumentView(title: "Backup Security", content: FAQBackupsSecurityFileContent())
             } label: {
                 Label("Are backups secure?", systemImage: "lock.fill")
+            }
+
+            NavigationLink {
+                SettingsDocumentView(title: "Moving Between Devices", content: FAQSyncDevicesFileContent())
+            } label: {
+                Label("How do I move items to another device?", systemImage: "iphone.and.arrow.forward")
             }
         } header: {
             Label("Backups", systemImage: "doc.on.doc.fill")


### PR DESCRIPTION
## Summary
- New Security section in HelpView with FAQ on per-item encryption (AES-GCM, password-derived key, contrasted with the native per-item lock).
- New entry in Backups section explaining cross-device transfer via backup/restore, including auto-backup to iCloud Drive as the closest available thing to sync.
- Two markdown files + two FileBackedContent classes wired through HelpView.

## Test plan
- [x] Build and run on simulator
- [x] Settings -> FAQs shows three sections in order: General, Security, Backups
- [x] Tap "Can I encrypt individual items?" -> markdown renders, title "Item Encryption"
- [x] Tap "How do I move items to another device?" -> markdown renders, title "Moving Between Devices"
- [x] No "error loading" fallback shown (confirms bundle resources resolved)

Generated with [Claude Code](https://claude.com/claude-code)