### PR TITLE
Fix killphrase oracle in vault-store deletion

### DIFF
--- a/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStore.swift
@@ -504,8 +504,11 @@ extension PersistedLocalVaultStore: VaultStoreKillphraseDeleter {
             try modelContext.save()
             return true
         } catch {
+            // Error path must be indistinguishable from "no match" to preserve the
+            // killphrase threat model — any signal here (crash, throw, log) is an
+            // oracle that confirms phrase validity to an attacker.
             modelContext.rollback()
-            fatalError("Crashing to protect data privacy – unable to delete killphrase item")
+            return false
         }
     }
 }

--- a/Vault/Sources/VaultFeed/Storage/VaultStore/VaultStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/VaultStore.swift
@@ -75,7 +75,13 @@ public protocol VaultStoreDeleter: Sendable {
 /// @mockable
 public protocol VaultStoreKillphraseDeleter: Sendable {
     /// Deletes items matching the given killphrase.
-    /// - Returns: `true` if any items were deleted, `false` otherwise
+    ///
+    /// - Returns: `true` if any items were deleted, `false` if no items matched
+    ///   **or** if an internal error prevented deletion.
+    /// - Important: This method intentionally returns the same value on "no match"
+    ///   and on internal failure so the killphrase feature does not leak phrase
+    ///   validity through error channels. Callers must not surface failures via
+    ///   UI, logs, or telemetry.
     @discardableResult
     func deleteItems(matchingKillphrase: String) async -> Bool
 }


### PR DESCRIPTION
## Summary

- `PersistedLocalVaultStore.deleteItems(matchingKillphrase:)` previously called `fatalError` when any SwiftData operation failed after a non-zero match count. The crash branch was reachable **only when the typed phrase actually matched items**, so any persistence error (locked store, schema migration, disk pressure, contention) became a deterministic oracle confirming phrase validity — and a denial-of-service vector against the killphrase feature.
- Replaced the `fatalError` with `modelContext.rollback()` + `return false`, matching the existing no-match branch. The error path is now observationally indistinguishable from "phrase did not match", preserving the killphrase threat model.
- Tightened the `VaultStoreKillphraseDeleter` protocol doc to record the invariant: `false` covers both "no match" and "internal failure", and callers must not surface failure through UI, logs, or telemetry.

## Threat model note

The killphrase feature is for use under coercion — typing it must look like a no-op to an observer who controls the device. A crash, a thrown error, a log line, or any UI change on the error path leaks phrase validity. This change closes the crash-channel oracle. The timing oracle (a correct phrase legitimately performs more work) is inherent to the feature and out of scope here. The plaintext storage of `killphrase` on `PersistedVaultItem` is a separate concern requiring a schema migration.

## Test plan

- [x] `make format` and `make lint` clean (already run locally).
- [x] Existing killphrase tests in `Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift` still pass (5 cases).
- [x] Manual: configure a killphrase on an item, search for that phrase in the simulator — item deleted on next reload (happy path unchanged).
- [ ] Manual error-path probe (optional, if reproducible): induce a SwiftData save error while searching for a correct killphrase — app must not crash and items must remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)