### PR TITLE
Add opt-in OTP code home/lock-screen widget

### DIFF
--- a/Vault/Package.swift
+++ b/Vault/Package.swift
@@ -37,6 +37,8 @@ let package = Package(
             targets: ["VaultiOS"],
         ),
         .library(name: "VaultiOSAutofill", targets: ["VaultiOSAutofill"]),
+        .library(name: "VaultiOSShared", targets: ["VaultiOSShared"]),
+        .library(name: "VaultiOSWidgets", targets: ["VaultiOSWidgets"]),
         .executable(
             name: "vault-keygen-speedtest",
             targets: ["VaultKeygenSpeedtest"],
@@ -57,10 +59,19 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "VaultiOSShared",
+            dependencies: [
+                "VaultFeed",
+            ],
+            swiftSettings: swiftSettings,
+            plugins: targetPlugins,
+        ),
+        .target(
             name: "VaultiOS",
             dependencies: [
                 "VaultFeed",
                 "VaultSettings",
+                "VaultiOSShared",
                 "CodeScanner",
                 "FoundationExtensions",
                 .product(name: "MarkdownUI", package: "swift-markdown-ui"),
@@ -270,6 +281,25 @@ let package = Package(
         .testTarget(
             name: "VaultiOSAutofillTests",
             dependencies: ["VaultiOSAutofill", "TestHelpers"],
+            swiftSettings: swiftSettings,
+            plugins: testTargetPlugins,
+        ),
+        .target(
+            name: "VaultiOSWidgets",
+            dependencies: [
+                "CryptoEngine",
+                "FoundationExtensions",
+                "VaultCore",
+                "VaultFeed",
+                "VaultiOSShared",
+            ],
+            swiftSettings: swiftSettings,
+            plugins: targetPlugins,
+        ),
+        .testTarget(
+            name: "VaultiOSWidgetsTests",
+            dependencies: ["VaultiOSWidgets", "VaultiOSShared", "TestHelpers"],
+            exclude: ["__Snapshots__"],
             swiftSettings: swiftSettings,
             plugins: testTargetPlugins,
         ),

--- a/Vault/Sources/VaultFeed/Presentation/VaultItemWidgetEligibility.swift
+++ b/Vault/Sources/VaultFeed/Presentation/VaultItemWidgetEligibility.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Determines whether a `VaultItem` may be surfaced in a home-screen / lock-screen widget.
+///
+/// Eligibility is **derived** from existing metadata fields rather than persisted as a
+/// per-item flag. A widget is a public surface — exposing an OTP code on it is a
+/// reduction in protection — so we never include items the user has marked as in any
+/// way sensitive: locked items, items hidden from the feed, items reachable only via
+/// search passphrase, and items protected by a killphrase.
+///
+/// The "opt-in" surface is the widget's configuration sheet, where the user picks
+/// from the set of items that pass this filter.
+public enum VaultItemWidgetEligibility {
+    /// Whether the given item may appear in the widget configuration picker and be
+    /// rendered by a widget timeline.
+    ///
+    /// An item is eligible iff every condition below holds:
+    /// - the payload is an `.otpCode`
+    /// - `lockState == .notLocked`
+    /// - `visibility == .always`
+    /// - `searchableLevel != .onlyPassphrase`
+    /// - `killphrase == nil`
+    ///
+    /// All five must hold; this is intentionally stricter than autofill eligibility,
+    /// which permits items hidden from the feed.
+    public static func isEligible(_ item: VaultItem) -> Bool {
+        guard case .otpCode = item.item else { return false }
+        return isEligible(metadata: item.metadata)
+    }
+
+    /// Metadata-only overload used by edit-screen code paths that have not yet
+    /// produced a full `VaultItem`. Callers must verify the payload is an OTP code
+    /// separately.
+    public static func isEligible(metadata: VaultItem.Metadata) -> Bool {
+        metadata.lockState == .notLocked
+            && metadata.visibility == .always
+            && metadata.searchableLevel != .onlyPassphrase
+            && metadata.killphrase == nil
+    }
+}

--- a/Vault/Sources/VaultFeed/Storage/VaultDataModel.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultDataModel.swift
@@ -301,6 +301,9 @@ extension VaultDataModel {
             // If killphrase deletion occurred, sync OTP autofill store to remove deleted items
             if didDeleteKillphraseItems {
                 try? await syncAllToOTPAutofillStore()
+                // Notify downstream observers (auto-backup, widget reload) that
+                // the item set changed silently from a killphrase match.
+                onDataChanged?()
             }
         } catch {
             itemsRetrievalError = PresentationError(
@@ -399,6 +402,7 @@ extension VaultDataModel: VaultStoreHOTPIncrementer {
     public func incrementCounter(id: Identifier<VaultItem>) async throws {
         try await vaultStore.incrementCounter(id: id)
         await reloadItems()
+        onDataChanged?()
     }
 }
 

--- a/Vault/Sources/VaultFeed/Storage/VaultSharedStorage.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultSharedStorage.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// The on-disk location shared between the main app and all extensions
+/// (autofill, widget) that need to read the vault.
+///
+/// All processes that read or write the vault must resolve the storage
+/// directory through this helper so the App Group identifier stays in one
+/// place. The widget extension cannot import `VaultiOS` and so must reach
+/// the same URL via this lightweight helper.
+public enum VaultSharedStorage {
+    /// The App Group identifier shared by the main app, autofill extension,
+    /// and widget extension. Must match the `com.apple.security.application-groups`
+    /// entitlement on every target that reads the vault.
+    public static let appGroupID = "group.com.badbundle.vault-group"
+
+    /// Resolves the App Group container URL. Crashes if the entitlement is
+    /// missing — there is no meaningful fallback because the vault cannot be
+    /// reached without it.
+    public static func directory(fileManager: FileManager = .default) -> URL {
+        guard let url = fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroupID) else {
+            fatalError("Unable to access App Group container '\(appGroupID)'")
+        }
+        return url
+    }
+}

--- a/Vault/Sources/VaultiOS/VaultRoot.swift
+++ b/Vault/Sources/VaultiOS/VaultRoot.swift
@@ -3,6 +3,9 @@ import FoundationExtensions
 import SwiftSecurity
 import VaultFeed
 import VaultSettings
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
 
 /// The root entrypoint for the vault application.
 ///
@@ -33,13 +36,7 @@ public enum VaultRoot {
     public static let secureStorage: some SecureStorage = SecureStorageImpl(keychain: keychain)
 
     @MainActor
-    static let vaultStorageDirectory: URL = {
-        let groupID = "group.com.badbundle.vault-group"
-        guard let url = fileManager.containerURL(forSecurityApplicationGroupIdentifier: groupID) else {
-            fatalError("Unable to access the provided directory")
-        }
-        return url
-    }()
+    static let vaultStorageDirectory: URL = VaultSharedStorage.directory(fileManager: fileManager)
 
     @MainActor
     public static let vaultStore: PersistedLocalVaultStore =
@@ -209,9 +206,19 @@ public enum VaultRoot {
     /// Call this at app startup to wire up connections between components.
     @MainActor
     public static func setup() {
-        // Wire up auto-backup to trigger when vault data changes
+        // Wire up auto-backup and widget reloads to trigger when vault data
+        // changes. The OTP widget reads items from the shared App Group
+        // container and only refreshes when the system or this hook asks it to.
         vaultDataModel.onDataChanged = {
             autoBackupService.notifyDataChanged()
+            reloadWidgetTimelines()
         }
+    }
+
+    @MainActor
+    private static func reloadWidgetTimelines() {
+        #if canImport(WidgetKit)
+        WidgetCenter.shared.reloadAllTimelines()
+        #endif
     }
 }

--- a/Vault/Sources/VaultiOS/Views/Previews/OTP/HOTPCodePreviewView.swift
+++ b/Vault/Sources/VaultiOS/Views/Previews/OTP/HOTPCodePreviewView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import VaultFeed
+import VaultiOSShared
 
 @MainActor
 struct HOTPCodePreviewView<ButtonView: View>: View {

--- a/Vault/Sources/VaultiOS/Views/Previews/OTP/TOTPCodePreviewView.swift
+++ b/Vault/Sources/VaultiOS/Views/Previews/OTP/TOTPCodePreviewView.swift
@@ -1,6 +1,7 @@
 import Combine
 import SwiftUI
 import VaultFeed
+import VaultiOSShared
 import VaultKeygen
 
 @MainActor

--- a/Vault/Sources/VaultiOS/Views/VaultMainScene.swift
+++ b/Vault/Sources/VaultiOS/Views/VaultMainScene.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Toasts
 import VaultFeed
+import VaultiOSShared
 import VaultSettings
 
 /// Entrypoint scene for the vault app.
@@ -27,6 +28,17 @@ public struct VaultMainScene: Scene {
                 injector: injector,
             )
             .installToast(position: .top)
+            .onOpenURL(perform: handle(url:))
+        }
+    }
+
+    private func handle(url: URL) {
+        guard let action = WidgetDeepLink.parse(url) else { return }
+        switch action {
+        case let .incrementHOTP(itemID):
+            Task {
+                try? await vaultDataModel.incrementCounter(id: .init(id: itemID))
+            }
         }
     }
 }

--- a/Vault/Sources/VaultiOSShared/OTPCodeTextView.swift
+++ b/Vault/Sources/VaultiOSShared/OTPCodeTextView.swift
@@ -1,12 +1,24 @@
-import Combine
 import SwiftUI
-import VaultFeed
+public import VaultFeed
+#if canImport(UIKit)
+import UIKit
+#endif
 
-struct OTPCodeTextView: View {
-    var codeState: OTPCodeState
-    var scaledDigitSpacing: Double = 8
+/// Renders an OTP code in the chunked, monospaced style used across all
+/// surfaces that present a code (in-app preview tile, widget, etc.). Lives in
+/// `VaultiOSShared` rather than `VaultiOS` so that lightweight surfaces — most
+/// notably WidgetKit extensions — can reuse the exact same rendering without
+/// pulling in the full `VaultiOS` dependency graph.
+public struct OTPCodeTextView: View {
+    public var codeState: OTPCodeState
+    public var scaledDigitSpacing: Double
 
-    var body: some View {
+    public init(codeState: OTPCodeState, scaledDigitSpacing: Double = 8) {
+        self.codeState = codeState
+        self.scaledDigitSpacing = scaledDigitSpacing
+    }
+
+    public var body: some View {
         switch codeState {
         case .notReady, .finished, .obfuscated:
             placeholderCode(digits: 6)
@@ -40,7 +52,11 @@ struct OTPCodeTextView: View {
     }
 
     private var spacing: Double {
+        #if canImport(UIKit)
         UIFontMetrics.default.scaledValue(for: scaledDigitSpacing)
+        #else
+        scaledDigitSpacing
+        #endif
     }
 
     private struct TextPart: Identifiable {

--- a/Vault/Sources/VaultiOSShared/WidgetDeepLink.swift
+++ b/Vault/Sources/VaultiOSShared/WidgetDeepLink.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Deep-link URLs that the widget hands back to the main app via `widgetURL(_:)`.
+///
+/// The main app's `onOpenURL` must understand these schemes. Centralised
+/// here so the widget and the app's URL handler agree on the format without
+/// passing strings through documentation.
+public enum WidgetDeepLink {
+    /// URL scheme. Must match the `CFBundleURLSchemes` entry in the main
+    /// app's `Info.plist`.
+    public static let scheme = "vault"
+
+    /// Tap target on HOTP widgets: opens the app and advances the counter
+    /// for the given item.
+    public static func hotpIncrement(itemID: UUID) -> URL {
+        URL(string: "\(scheme)://otp/\(itemID.uuidString)/increment").unsafelyUnwrapped
+    }
+
+    /// Parses a URL produced by one of the constructors above. Returns nil
+    /// if the URL does not match a known shape.
+    public static func parse(_ url: URL) -> Action? {
+        guard url.scheme == scheme else { return nil }
+        let parts = url.pathComponents.filter { $0 != "/" }
+        switch (url.host, parts) {
+        case let ("otp", components) where components.count == 2 && components[1] == "increment":
+            guard let id = UUID(uuidString: components[0]) else { return nil }
+            return .incrementHOTP(itemID: id)
+        default:
+            return nil
+        }
+    }
+
+    public enum Action: Equatable, Sendable {
+        case incrementHOTP(itemID: UUID)
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/Intent/OTPWidgetIntent.swift
+++ b/Vault/Sources/VaultiOSWidgets/Intent/OTPWidgetIntent.swift
@@ -1,0 +1,19 @@
+import AppIntents
+import WidgetKit
+
+/// Configuration intent backing the OTP widget's edit sheet. The user picks
+/// a single OTP item; everything else is derived from current item state at
+/// timeline-build time.
+public struct OTPWidgetIntent: WidgetConfigurationIntent {
+    public nonisolated static let title: LocalizedStringResource = "Pick OTP Code"
+    public nonisolated static let description = IntentDescription("Show a one-time code in the widget.")
+
+    @Parameter(title: "Code")
+    public var item: OTPWidgetItemEntity?
+
+    public init() {}
+
+    public init(item: OTPWidgetItemEntity?) {
+        self.item = item
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/Intent/OTPWidgetItemEntity.swift
+++ b/Vault/Sources/VaultiOSWidgets/Intent/OTPWidgetItemEntity.swift
@@ -1,0 +1,78 @@
+import AppIntents
+import Foundation
+import VaultFeed
+
+/// User-selectable widget item shown in the widget's edit sheet.
+///
+/// The list of entities exposed by `Query` is **filtered to eligible items
+/// only** (see `VaultItemWidgetEligibility`). Items that the user has marked
+/// hidden, locked, killphrase-protected, or search-passphrase-gated never
+/// appear here.
+public struct OTPWidgetItemEntity: AppEntity, Identifiable, Hashable {
+    public var id: UUID
+    public var issuer: String
+    public var accountName: String
+
+    public init(id: UUID, issuer: String, accountName: String) {
+        self.id = id
+        self.issuer = issuer
+        self.accountName = accountName
+    }
+
+    public var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(
+            title: "\(displayTitle)",
+            subtitle: accountName.isEmpty ? nil : "\(accountName)",
+        )
+    }
+
+    private var displayTitle: String {
+        issuer.isEmpty ? accountName : issuer
+    }
+
+    public nonisolated static let typeDisplayRepresentation: TypeDisplayRepresentation = .init(name: "OTP Code")
+
+    public nonisolated static let defaultQuery = OTPWidgetItemEntityQuery()
+}
+
+/// Provides the dynamic options shown in the widget configuration picker.
+/// Only eligible OTP items are returned — see `VaultItemWidgetEligibility`.
+public struct OTPWidgetItemEntityQuery: EntityQuery, Sendable {
+    public typealias Entity = OTPWidgetItemEntity
+
+    private let loader: WidgetVaultLoader
+
+    public init() {
+        loader = .shared
+    }
+
+    public init(loader: WidgetVaultLoader) {
+        self.loader = loader
+    }
+
+    public func entities(for identifiers: [OTPWidgetItemEntity.ID]) async throws -> [OTPWidgetItemEntity] {
+        let lookup = Set(identifiers)
+        let items = try await loader.eligibleItems()
+        return items
+            .filter { lookup.contains($0.id.rawValue) }
+            .compactMap(Self.makeEntity(from:))
+    }
+
+    public func suggestedEntities() async throws -> [OTPWidgetItemEntity] {
+        let items = try await loader.eligibleItems()
+        return items.compactMap(Self.makeEntity(from:))
+    }
+
+    public func defaultResult() async -> OTPWidgetItemEntity? {
+        try? await suggestedEntities().first
+    }
+
+    private static func makeEntity(from item: VaultItem) -> OTPWidgetItemEntity? {
+        guard case let .otpCode(otp) = item.item else { return nil }
+        return OTPWidgetItemEntity(
+            id: item.id.rawValue,
+            issuer: otp.data.issuer,
+            accountName: otp.data.accountName,
+        )
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/Loader/WidgetVaultLoader.swift
+++ b/Vault/Sources/VaultiOSWidgets/Loader/WidgetVaultLoader.swift
@@ -1,0 +1,48 @@
+import Foundation
+import FoundationExtensions
+public import VaultCore
+public import VaultFeed
+
+/// Reads the shared vault store from the widget extension process and
+/// surfaces only those items that pass `VaultItemWidgetEligibility`.
+///
+/// The widget extension cannot link `VaultiOS` (and therefore cannot use
+/// `VaultRoot.vaultStore`), so this type opens its own `PersistedLocalVaultStore`
+/// pointed at the same App Group container.
+public actor WidgetVaultLoader {
+    /// Process-wide default instance. Widget timeline providers should reuse
+    /// the same loader across calls so the underlying `ModelContainer` is
+    /// built once.
+    public static let shared = WidgetVaultLoader()
+
+    private let store: PersistedLocalVaultStore
+
+    public init(store: PersistedLocalVaultStore? = nil) {
+        if let store {
+            self.store = store
+        } else {
+            self.store = PersistedLocalVaultStoreFactory(
+                storageDirectory: VaultSharedStorage.directory(),
+            ).makeVaultStore()
+        }
+    }
+
+    /// All items that are currently eligible to appear in a widget. Hidden,
+    /// locked, killphrase-protected, and search-passphrase items are filtered
+    /// out — see `VaultItemWidgetEligibility`.
+    public func eligibleItems() async throws -> [VaultItem] {
+        let result = try await store.retrieve(query: .init())
+        return result.items.filter(VaultItemWidgetEligibility.isEligible)
+    }
+
+    /// Fetch a single eligible item by id. Returns `nil` when the item does
+    /// not exist or has become ineligible since the user configured the widget.
+    /// The two states are indistinguishable to callers by design (manifesto C2).
+    public func eligibleItem(id: UUID) async throws -> VaultItem? {
+        let result = try await store.retrieve(query: .init())
+        guard let item = result.items.first(where: { $0.id.rawValue == id }) else {
+            return nil
+        }
+        return VaultItemWidgetEligibility.isEligible(item) ? item : nil
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/OTPWidget.swift
+++ b/Vault/Sources/VaultiOSWidgets/OTPWidget.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+import WidgetKit
+
+/// The OTP code widget. Embed in a `WidgetBundle` inside the widget
+/// extension target:
+///
+/// ```swift
+/// @main
+/// struct VaultWidgetsBundle: WidgetBundle {
+///     var body: some Widget { OTPWidget() }
+/// }
+/// ```
+public struct OTPWidget: Widget {
+    /// Stable kind identifier used by `WidgetCenter` to reload timelines.
+    public static let kind = "com.badbundle.vault.OTPWidget"
+
+    public init() {}
+
+    public var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: Self.kind,
+            intent: OTPWidgetIntent.self,
+            provider: OTPWidgetProvider(),
+        ) { entry in
+            OTPWidgetEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("OTP Code")
+        .description("Show a one-time code from your vault.")
+        .supportedFamilies([
+            .systemSmall,
+            .accessoryRectangular,
+            .accessoryCircular,
+        ])
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/OTPWidgetEntry.swift
+++ b/Vault/Sources/VaultiOSWidgets/OTPWidgetEntry.swift
@@ -1,0 +1,85 @@
+import Foundation
+import WidgetKit
+
+/// Single timeline entry for the OTP widget. The `snapshot` carries
+/// everything the view needs to render at a point in time; entries are
+/// otherwise opaque to callers.
+public struct OTPWidgetEntry: TimelineEntry, Sendable {
+    public var date: Date
+    public var snapshot: OTPWidgetSnapshot
+
+    public init(date: Date, snapshot: OTPWidgetSnapshot) {
+        self.date = date
+        self.snapshot = snapshot
+    }
+}
+
+/// Renderable state for the widget. Modeled as an enum so the "unavailable"
+/// and "placeholder" states are first-class — a deleted or newly-hidden item
+/// must render identically to one that never existed, so views cannot
+/// distinguish them (manifesto C2).
+public enum OTPWidgetSnapshot: Sendable, Equatable {
+    /// Pre-data placeholder used by `placeholder(in:)` and snapshot calls.
+    /// Should never reveal real item content.
+    case placeholder
+
+    /// Item is missing, ineligible, or could not be loaded. Rendered the
+    /// same way regardless of cause.
+    case unavailable
+
+    /// Live TOTP code valid until `periodEnd`. Progress bars use the
+    /// `[periodStart, periodEnd]` interval directly.
+    case totp(TOTP)
+
+    /// HOTP code captured at the time the entry was built. The widget never
+    /// auto-increments — the user must tap the widget to open the app and
+    /// advance the counter.
+    case hotp(HOTP)
+
+    public struct TOTP: Sendable, Equatable {
+        public var issuer: String
+        public var accountName: String
+        public var code: String
+        public var digits: Int
+        public var periodStart: Date
+        public var periodEnd: Date
+
+        public init(
+            issuer: String,
+            accountName: String,
+            code: String,
+            digits: Int,
+            periodStart: Date,
+            periodEnd: Date,
+        ) {
+            self.issuer = issuer
+            self.accountName = accountName
+            self.code = code
+            self.digits = digits
+            self.periodStart = periodStart
+            self.periodEnd = periodEnd
+        }
+    }
+
+    public struct HOTP: Sendable, Equatable {
+        public var itemID: UUID
+        public var issuer: String
+        public var accountName: String
+        public var code: String
+        public var digits: Int
+
+        public init(
+            itemID: UUID,
+            issuer: String,
+            accountName: String,
+            code: String,
+            digits: Int,
+        ) {
+            self.itemID = itemID
+            self.issuer = issuer
+            self.accountName = accountName
+            self.code = code
+            self.digits = digits
+        }
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/OTPWidgetProvider.swift
+++ b/Vault/Sources/VaultiOSWidgets/OTPWidgetProvider.swift
@@ -1,0 +1,155 @@
+import AppIntents
+import Foundation
+import VaultCore
+import VaultFeed
+import WidgetKit
+
+/// Builds widget timeline entries from the user's selected OTP item.
+///
+/// TOTP entries advance at period boundaries — we emit the current period's
+/// entry plus the next period's entry so the in-progress and rolled-over
+/// codes are both ready without a round trip. HOTP entries are static
+/// snapshots of the last persisted counter value; the app must reload the
+/// timeline after incrementing.
+///
+/// Items that have become ineligible since the user configured the widget
+/// (locked, hidden, killphrased, etc.) render as `.unavailable` — the same
+/// state shown for deleted or missing items, so a viewer cannot distinguish
+/// the two (manifesto C2).
+public struct OTPWidgetProvider: AppIntentTimelineProvider {
+    public typealias Entry = OTPWidgetEntry
+    public typealias Intent = OTPWidgetIntent
+
+    /// How long an unavailable entry remains in the timeline before the
+    /// system asks for a fresh one. Recovers from transient store-open
+    /// failures without spinning the CPU.
+    private static let unavailableRefreshInterval: TimeInterval = 15 * 60
+
+    private let loader: WidgetVaultLoader
+
+    public init(loader: WidgetVaultLoader = .shared) {
+        self.loader = loader
+    }
+
+    public func placeholder(in _: Context) -> OTPWidgetEntry {
+        OTPWidgetEntry(date: Date(), snapshot: .placeholder)
+    }
+
+    public func snapshot(for _: OTPWidgetIntent, in _: Context) async -> OTPWidgetEntry {
+        // Snapshot is used for the widget gallery, transitions, and previews.
+        // Never leak real codes here — placeholder is sufficient and safer.
+        OTPWidgetEntry(date: Date(), snapshot: .placeholder)
+    }
+
+    public func timeline(
+        for configuration: OTPWidgetIntent,
+        in _: Context,
+    ) async -> Timeline<OTPWidgetEntry> {
+        guard let entityID = configuration.item?.id else {
+            return unavailableTimeline()
+        }
+
+        guard let item = try? await loader.eligibleItem(id: entityID),
+              case let .otpCode(otp) = item.item
+        else {
+            return unavailableTimeline()
+        }
+
+        switch otp.type {
+        case let .totp(period):
+            return totpTimeline(otp: otp, period: period)
+        case let .hotp(counter):
+            return hotpTimeline(itemID: item.id.rawValue, otp: otp, counter: counter)
+        }
+    }
+
+    // MARK: - TOTP
+
+    private func totpTimeline(
+        otp: OTPAuthCode,
+        period: UInt64,
+    ) -> Timeline<OTPWidgetEntry> {
+        let now = Date()
+        let nowEpoch = now.timeIntervalSince1970
+        let currentState = OTPCodeTimerState(currentTime: nowEpoch, period: period)
+        let nextState = currentState.offset(time: Double(period))
+
+        let entries: [OTPWidgetEntry] = [
+            makeTOTPEntry(at: now, otp: otp, period: period, state: currentState),
+            makeTOTPEntry(
+                at: Date(timeIntervalSince1970: currentState.endTime),
+                otp: otp,
+                period: period,
+                state: nextState,
+            ),
+        ].compactMap(\.self)
+
+        if entries.isEmpty {
+            return unavailableTimeline()
+        }
+        return Timeline(
+            entries: entries,
+            policy: .after(Date(timeIntervalSince1970: nextState.endTime)),
+        )
+    }
+
+    private func makeTOTPEntry(
+        at date: Date,
+        otp: OTPAuthCode,
+        period: UInt64,
+        state: OTPCodeTimerState,
+    ) -> OTPWidgetEntry? {
+        let totp = TOTPAuthCode(period: period, data: otp.data)
+        let epochSeconds = UInt64(state.startTime)
+        guard let rendered = try? totp.renderCode(epochSeconds: epochSeconds) else {
+            return nil
+        }
+        return OTPWidgetEntry(
+            date: date,
+            snapshot: .totp(.init(
+                issuer: otp.data.issuer,
+                accountName: otp.data.accountName,
+                code: rendered,
+                digits: Int(otp.data.digits.value),
+                periodStart: Date(timeIntervalSince1970: state.startTime),
+                periodEnd: Date(timeIntervalSince1970: state.endTime),
+            )),
+        )
+    }
+
+    // MARK: - HOTP
+
+    private func hotpTimeline(
+        itemID: UUID,
+        otp: OTPAuthCode,
+        counter: UInt64,
+    ) -> Timeline<OTPWidgetEntry> {
+        let hotp = HOTPAuthCode(counter: counter, data: otp.data)
+        guard let rendered = try? hotp.renderCode() else {
+            return unavailableTimeline()
+        }
+        let entry = OTPWidgetEntry(
+            date: Date(),
+            snapshot: .hotp(.init(
+                itemID: itemID,
+                issuer: otp.data.issuer,
+                accountName: otp.data.accountName,
+                code: rendered,
+                digits: Int(otp.data.digits.value),
+            )),
+        )
+        // HOTP only refreshes when the app pings `WidgetCenter.reloadAllTimelines()`
+        // after the user increments the counter via deep link.
+        return Timeline(entries: [entry], policy: .never)
+    }
+
+    // MARK: - Unavailable
+
+    private func unavailableTimeline() -> Timeline<OTPWidgetEntry> {
+        let entry = OTPWidgetEntry(date: Date(), snapshot: .unavailable)
+        return Timeline(
+            entries: [entry],
+            policy: .after(Date().addingTimeInterval(Self.unavailableRefreshInterval)),
+        )
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetAccessoryCircularView.swift
+++ b/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetAccessoryCircularView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import VaultiOSShared
+import WidgetKit
+
+/// `accessoryCircular` (lock-screen ring) layout. Too small for the chunked
+/// code in a readable size; we show the seconds remaining inside the ring
+/// (TOTP) or a key glyph (HOTP / unavailable) and let the user open the app
+/// to read the actual code.
+struct OTPWidgetAccessoryCircularView: View {
+    let snapshot: OTPWidgetSnapshot
+
+    var body: some View {
+        ZStack {
+            switch snapshot {
+            case let .totp(state):
+                ProgressView(
+                    timerInterval: state.periodStart ... state.periodEnd,
+                    countsDown: true,
+                ) {
+                    Text(state.code.suffix(3))
+                        .font(.system(.caption2, design: .monospaced).weight(.semibold))
+                } currentValueLabel: {
+                    Text(state.code.suffix(3))
+                        .font(.system(.caption2, design: .monospaced).weight(.semibold))
+                }
+                .progressViewStyle(.circular)
+            case .hotp:
+                Image(systemName: "key.horizontal.fill")
+                    .font(.title3)
+            case .unavailable, .placeholder:
+                Image(systemName: "lock.fill")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .widgetURL(deepLinkURL)
+    }
+
+    private var deepLinkURL: URL? {
+        switch snapshot {
+        case let .hotp(state): WidgetDeepLink.hotpIncrement(itemID: state.itemID)
+        case .totp, .unavailable, .placeholder: nil
+        }
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetAccessoryRectangularView.swift
+++ b/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetAccessoryRectangularView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import VaultFeed
+import VaultiOSShared
+import WidgetKit
+
+/// `accessoryRectangular` (lock-screen rectangular) layout. Tight space —
+/// issuer caption, chunked digits, thin progress bar.
+struct OTPWidgetAccessoryRectangularView: View {
+    let snapshot: OTPWidgetSnapshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(issuerLine)
+                .font(.caption2)
+                .lineLimit(1)
+
+            OTPCodeTextView(codeState: codeState, scaledDigitSpacing: 3)
+                .font(.system(.title3, design: .monospaced))
+                .fontWeight(.semibold)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+
+            timerBar
+                .frame(height: 3)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .widgetURL(deepLinkURL)
+    }
+
+    @ViewBuilder
+    private var timerBar: some View {
+        switch snapshot {
+        case let .totp(state):
+            ProgressView(
+                timerInterval: state.periodStart ... state.periodEnd,
+                countsDown: true,
+                label: { EmptyView() },
+                currentValueLabel: { EmptyView() },
+            )
+            .progressViewStyle(.linear)
+        case .hotp, .unavailable, .placeholder:
+            Color.gray.opacity(0.3).clipShape(Capsule())
+        }
+    }
+
+    private var codeState: OTPCodeState {
+        switch snapshot {
+        case let .totp(state): .visible(state.code)
+        case let .hotp(state): .visible(state.code)
+        case .unavailable, .placeholder: .notReady
+        }
+    }
+
+    private var issuerLine: String {
+        switch snapshot {
+        case let .totp(state):
+            state.issuer.isEmpty ? state.accountName : state.issuer
+        case let .hotp(state):
+            state.issuer.isEmpty ? state.accountName : state.issuer
+        case .unavailable: "Unavailable"
+        case .placeholder: "—"
+        }
+    }
+
+    private var deepLinkURL: URL? {
+        switch snapshot {
+        case let .hotp(state): WidgetDeepLink.hotpIncrement(itemID: state.itemID)
+        case .totp, .unavailable, .placeholder: nil
+        }
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetEntryView.swift
+++ b/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetEntryView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import WidgetKit
+
+/// Top-level widget view that dispatches to the right per-family layout.
+public struct OTPWidgetEntryView: View {
+    @Environment(\.widgetFamily) private var family
+
+    public var entry: OTPWidgetEntry
+
+    public init(entry: OTPWidgetEntry) {
+        self.entry = entry
+    }
+
+    public var body: some View {
+        switch family {
+        case .systemSmall:
+            OTPWidgetSmallView(snapshot: entry.snapshot)
+        case .accessoryRectangular:
+            OTPWidgetAccessoryRectangularView(snapshot: entry.snapshot)
+        case .accessoryCircular:
+            OTPWidgetAccessoryCircularView(snapshot: entry.snapshot)
+        default:
+            OTPWidgetSmallView(snapshot: entry.snapshot)
+        }
+    }
+}

--- a/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetSmallView.swift
+++ b/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetSmallView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import VaultFeed
+import VaultiOSShared
+import WidgetKit
+
+/// `systemSmall` layout. Mirrors `TOTPCodePreviewView` from the in-app
+/// preview tile — icon top-left, issuer/account stack, large monospaced
+/// chunked digits, horizontal progress bar at the bottom.
+struct OTPWidgetSmallView: View {
+    let snapshot: OTPWidgetSnapshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            icon
+                .padding(.bottom, 8)
+
+            labelsStack
+
+            codeSection
+                .padding(.vertical, 12)
+
+            Spacer(minLength: 0)
+
+            timerBar
+                .frame(height: 12)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .widgetURL(deepLinkURL)
+    }
+
+    // MARK: - Pieces
+
+    @ViewBuilder
+    private var icon: some View {
+        Image(systemName: "key.horizontal.fill")
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(.secondary)
+    }
+
+    private var labelsStack: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(displayIssuer)
+                .font(issuerFont)
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+
+            Text(displayAccount)
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var codeSection: some View {
+        OTPCodeTextView(codeState: codeState)
+            .font(.system(size: 36, design: .monospaced))
+            .fontWeight(.heavy)
+            .minimumScaleFactor(0.5)
+            .lineLimit(1)
+            .foregroundColor(.primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var timerBar: some View {
+        switch snapshot {
+        case let .totp(state):
+            ProgressView(
+                timerInterval: state.periodStart ... state.periodEnd,
+                countsDown: true,
+                label: { EmptyView() },
+                currentValueLabel: { EmptyView() },
+            )
+            .progressViewStyle(.linear)
+            .tint(.accentColor)
+        case .hotp, .unavailable, .placeholder:
+            Color.gray.opacity(0.3)
+        }
+    }
+
+    // MARK: - Snapshot accessors
+
+    private var codeState: OTPCodeState {
+        switch snapshot {
+        case let .totp(state): .visible(state.code)
+        case let .hotp(state): .visible(state.code)
+        case .unavailable, .placeholder: .notReady
+        }
+    }
+
+    private var displayIssuer: String {
+        switch snapshot {
+        case let .totp(state): state.issuer.isEmpty ? state.accountName : state.issuer
+        case let .hotp(state): state.issuer.isEmpty ? state.accountName : state.issuer
+        case .unavailable: "Unavailable"
+        case .placeholder: "—"
+        }
+    }
+
+    private var displayAccount: String {
+        switch snapshot {
+        case let .totp(state): state.accountName
+        case let .hotp(state): state.accountName
+        case .unavailable: "Open Vault to set up"
+        case .placeholder: ""
+        }
+    }
+
+    private var deepLinkURL: URL? {
+        switch snapshot {
+        case let .hotp(state): WidgetDeepLink.hotpIncrement(itemID: state.itemID)
+        case .totp, .unavailable, .placeholder: nil
+        }
+    }
+
+    private var issuerFont: Font {
+        let length = displayIssuer.count
+        switch length {
+        case 0 ... 20: return .title3.weight(.bold)
+        case 21 ... 35: return .system(size: 18, weight: .bold)
+        case 36 ... 50: return .system(size: 16, weight: .bold)
+        default: return .system(size: 14, weight: .bold)
+        }
+    }
+}

--- a/Vault/Tests/VaultFeedTests/Presentation/VaultItemWidgetEligibilityTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/VaultItemWidgetEligibilityTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import FoundationExtensions
+import Testing
+import VaultCore
+@testable import VaultFeed
+
+@Suite
+struct VaultItemWidgetEligibilityTests {
+    @Test
+    func eligible_whenAllConditionsHold() {
+        let item = uniqueVaultItem(
+            visibility: .always,
+            searchableLevel: .full,
+            killphrase: nil,
+            lockState: .notLocked,
+        )
+        #expect(VaultItemWidgetEligibility.isEligible(item))
+    }
+
+    @Test
+    func ineligible_whenPayloadIsNotOTP() {
+        let note = SecureNote(title: "t", contents: "c", format: .markdown)
+        let item = uniqueVaultItem(item: .secureNote(note))
+        #expect(!VaultItemWidgetEligibility.isEligible(item))
+    }
+
+    @Test
+    func ineligible_whenLocked() {
+        let item = uniqueVaultItem(lockState: .lockedWithNativeSecurity)
+        #expect(!VaultItemWidgetEligibility.isEligible(item))
+    }
+
+    @Test
+    func ineligible_whenVisibilityIsOnlySearch() {
+        let item = uniqueVaultItem(visibility: .onlySearch)
+        #expect(!VaultItemWidgetEligibility.isEligible(item))
+    }
+
+    @Test
+    func ineligible_whenSearchableLevelIsOnlyPassphrase() {
+        let item = uniqueVaultItem(searchableLevel: .onlyPassphrase)
+        #expect(!VaultItemWidgetEligibility.isEligible(item))
+    }
+
+    @Test
+    func ineligible_whenKillphraseIsSet() {
+        let item = uniqueVaultItem(killphrase: "any-phrase")
+        #expect(!VaultItemWidgetEligibility.isEligible(item))
+    }
+
+    @Test
+    func metadataOnlyOverload_matchesMetadataFields() {
+        let metadata = anyVaultItemMetadata(
+            visibility: .always,
+            searchableLevel: .full,
+            killphrase: nil,
+            lockState: .notLocked,
+        )
+        #expect(VaultItemWidgetEligibility.isEligible(metadata: metadata))
+
+        let lockedMetadata = anyVaultItemMetadata(lockState: .lockedWithNativeSecurity)
+        #expect(!VaultItemWidgetEligibility.isEligible(metadata: lockedMetadata))
+    }
+}

--- a/Vault/Tests/VaultiOSTests/OTPCodeTextViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/OTPCodeTextViewSnapshotTests.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import TestHelpers
 import Testing
 import VaultFeed
+import VaultiOSShared
 @testable import VaultiOS
 
 @Suite

--- a/Vault/Tests/VaultiOSWidgetsTests/WidgetDeepLinkTests.swift
+++ b/Vault/Tests/VaultiOSWidgetsTests/WidgetDeepLinkTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import VaultiOSShared
+
+@Suite
+struct WidgetDeepLinkTests {
+    @Test
+    func hotpIncrement_roundTripsViaParse() {
+        let id = UUID(uuidString: "12345678-1234-1234-1234-123456789ABC").unsafelyUnwrapped
+        let url = WidgetDeepLink.hotpIncrement(itemID: id)
+        let action = WidgetDeepLink.parse(url)
+        #expect(action == .incrementHOTP(itemID: id))
+    }
+
+    @Test
+    func parse_returnsNil_forUnknownScheme() {
+        let url = URL(string: "https://example.com/otp/abc/increment").unsafelyUnwrapped
+        #expect(WidgetDeepLink.parse(url) == nil)
+    }
+
+    @Test
+    func parse_returnsNil_forUnknownHost() {
+        let url = URL(string: "vault://settings/foo").unsafelyUnwrapped
+        #expect(WidgetDeepLink.parse(url) == nil)
+    }
+
+    @Test
+    func parse_returnsNil_forUnknownAction() {
+        let url = URL(string: "vault://otp/12345678-1234-1234-1234-123456789ABC/delete").unsafelyUnwrapped
+        #expect(WidgetDeepLink.parse(url) == nil)
+    }
+
+    @Test
+    func parse_returnsNil_forMissingItemID() {
+        let url = URL(string: "vault://otp/increment").unsafelyUnwrapped
+        #expect(WidgetDeepLink.parse(url) == nil)
+    }
+
+    @Test
+    func parse_returnsNil_forMalformedUUID() {
+        let url = URL(string: "vault://otp/not-a-uuid/increment").unsafelyUnwrapped
+        #expect(WidgetDeepLink.parse(url) == nil)
+    }
+}

--- a/VaultApp/VaultApp.xcodeproj/project.pbxproj
+++ b/VaultApp/VaultApp.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		1C1318072AD75008006F14F5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1C1317FB2AD75008006F14F5 /* Assets.xcassets */; };
 		1C2856652ADFF39800DA4AA9 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1C1317FE2AD75008006F14F5 /* Preview Assets.xcassets */; };
 		1C45B07C2ADFE8BE00197B32 /* VaultAppMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C45B07B2ADFE8BE00197B32 /* VaultAppMain.swift */; };
+		1C4688E32FC8D77F004E2279 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C4688E22FC8D77F004E2279 /* WidgetKit.framework */; };
+		1C4688E52FC8D77F004E2279 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C4688E42FC8D77F004E2279 /* SwiftUI.framework */; };
+		1C4688F62FC8D77F004E2279 /* VaultWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 1C4688E12FC8D77F004E2279 /* VaultWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		1C4688FC2FC8D7E9004E2279 /* VaultiOSWidgets in Frameworks */ = {isa = PBXBuildFile; productRef = 1C4688FB2FC8D7E9004E2279 /* VaultiOSWidgets */; };
 		1C58F2F32AE5764100962BAB /* VaultiOS in Frameworks */ = {isa = PBXBuildFile; productRef = 1C58F2F22AE5764100962BAB /* VaultiOS */; };
 		1C8B89F52CD3759400F3D340 /* VaultiOSAutofill in Frameworks */ = {isa = PBXBuildFile; productRef = 1C8B89F42CD3759400F3D340 /* VaultiOSAutofill */; };
 		1CBE0CCD2CD229FF000EA09D /* AuthenticationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBE0CCC2CD229FF000EA09D /* AuthenticationServices.framework */; };
@@ -17,6 +21,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1C4688F42FC8D77F004E2279 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1CDA9C892A057A8B00555E7A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1C4688E02FC8D77F004E2279;
+			remoteInfo = VaultWidgetsExtension;
+		};
 		1CBE0CD62CD229FF000EA09D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 1CDA9C892A057A8B00555E7A /* Project object */;
@@ -34,6 +45,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				1CBE0CD82CD229FF000EA09D /* VaultAppAutofill.appex in Embed Foundation Extensions */,
+				1C4688F62FC8D77F004E2279 /* VaultWidgetsExtension.appex in Embed Foundation Extensions */,
 			);
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -45,6 +57,10 @@
 		1C1317FE2AD75008006F14F5 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		1C1318012AD75008006F14F5 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1C45B07B2ADFE8BE00197B32 /* VaultAppMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultAppMain.swift; sourceTree = "<group>"; };
+		1C4688E12FC8D77F004E2279 /* VaultWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = VaultWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		1C4688E22FC8D77F004E2279 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		1C4688E42FC8D77F004E2279 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
+		1C4688FD2FC8D806004E2279 /* VaultWidgetsExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VaultWidgetsExtension.entitlements; sourceTree = "<group>"; };
 		1C648DFB2C0A884500163D41 /* VaultApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VaultApp.entitlements; sourceTree = "<group>"; };
 		1CBE0CCB2CD229FF000EA09D /* VaultAppAutofill.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = VaultAppAutofill.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CBE0CCC2CD229FF000EA09D /* AuthenticationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AuthenticationServices.framework; path = System/Library/Frameworks/AuthenticationServices.framework; sourceTree = SDKROOT; };
@@ -52,6 +68,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		1C4688F92FC8D77F004E2279 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 1C4688E02FC8D77F004E2279 /* VaultWidgetsExtension */;
+		};
 		1CBE0CDC2CD229FF000EA09D /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -62,10 +85,21 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		1C4688E62FC8D77F004E2279 /* VaultWidgets */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (1C4688F92FC8D77F004E2279 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = VaultWidgets; sourceTree = "<group>"; };
 		1CBE0CCE2CD229FF000EA09D /* VaultAppAutofill */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (1CBE0CDC2CD229FF000EA09D /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = VaultAppAutofill; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1C4688DE2FC8D77F004E2279 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1C4688E52FC8D77F004E2279 /* SwiftUI.framework in Frameworks */,
+				1C4688E32FC8D77F004E2279 /* WidgetKit.framework in Frameworks */,
+				1C4688FC2FC8D7E9004E2279 /* VaultiOSWidgets in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1CBE0CC82CD229FF000EA09D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -109,8 +143,10 @@
 		1CDA9C882A057A8B00555E7A = {
 			isa = PBXGroup;
 			children = (
+				1C4688FD2FC8D806004E2279 /* VaultWidgetsExtension.entitlements */,
 				1C1317F62AD75008006F14F5 /* VaultApp */,
 				1CBE0CCE2CD229FF000EA09D /* VaultAppAutofill */,
+				1C4688E62FC8D77F004E2279 /* VaultWidgets */,
 				1CDA9C922A057A8B00555E7A /* Products */,
 				1CDA9CC12A057ADC00555E7A /* Frameworks */,
 			);
@@ -121,6 +157,7 @@
 			children = (
 				1CDA9C912A057A8B00555E7A /* VaultApp.app */,
 				1CBE0CCB2CD229FF000EA09D /* VaultAppAutofill.appex */,
+				1C4688E12FC8D77F004E2279 /* VaultWidgetsExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -129,6 +166,8 @@
 			isa = PBXGroup;
 			children = (
 				1CBE0CCC2CD229FF000EA09D /* AuthenticationServices.framework */,
+				1C4688E22FC8D77F004E2279 /* WidgetKit.framework */,
+				1C4688E42FC8D77F004E2279 /* SwiftUI.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -136,6 +175,29 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		1C4688E02FC8D77F004E2279 /* VaultWidgetsExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1C4688FA2FC8D77F004E2279 /* Build configuration list for PBXNativeTarget "VaultWidgetsExtension" */;
+			buildPhases = (
+				1C4688DD2FC8D77F004E2279 /* Sources */,
+				1C4688DE2FC8D77F004E2279 /* Frameworks */,
+				1C4688DF2FC8D77F004E2279 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				1C4688E62FC8D77F004E2279 /* VaultWidgets */,
+			);
+			name = VaultWidgetsExtension;
+			packageProductDependencies = (
+				1C4688FB2FC8D7E9004E2279 /* VaultiOSWidgets */,
+			);
+			productName = VaultWidgetsExtension;
+			productReference = 1C4688E12FC8D77F004E2279 /* VaultWidgetsExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		1CBE0CCA2CD229FF000EA09D /* VaultAppAutofill */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1CBE0CDD2CD229FF000EA09D /* Build configuration list for PBXNativeTarget "VaultAppAutofill" */;
@@ -172,6 +234,7 @@
 			);
 			dependencies = (
 				1CBE0CD72CD229FF000EA09D /* PBXTargetDependency */,
+				1C4688F52FC8D77F004E2279 /* PBXTargetDependency */,
 			);
 			name = VaultApp;
 			packageProductDependencies = (
@@ -188,9 +251,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 2610;
+				LastSwiftUpdateCheck = 2650;
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
+					1C4688E02FC8D77F004E2279 = {
+						CreatedOnToolsVersion = 26.5;
+					};
 					1CBE0CCA2CD229FF000EA09D = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -214,11 +280,19 @@
 			targets = (
 				1CDA9C902A057A8B00555E7A /* VaultApp */,
 				1CBE0CCA2CD229FF000EA09D /* VaultAppAutofill */,
+				1C4688E02FC8D77F004E2279 /* VaultWidgetsExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1C4688DF2FC8D77F004E2279 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1CBE0CC92CD229FF000EA09D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -238,6 +312,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1C4688DD2FC8D77F004E2279 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1CBE0CC72CD229FF000EA09D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -256,6 +337,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1C4688F52FC8D77F004E2279 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1C4688E02FC8D77F004E2279 /* VaultWidgetsExtension */;
+			targetProxy = 1C4688F42FC8D77F004E2279 /* PBXContainerItemProxy */;
+		};
 		1CBE0CD72CD229FF000EA09D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 1CBE0CCA2CD229FF000EA09D /* VaultAppAutofill */;
@@ -264,6 +350,77 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		1C4688F72FC8D77F004E2279 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPINTENTS_PACKAGE_DEPENDENCIES = VaultiOSWidgets;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = VaultWidgetsExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APPINTENTS_METADATA_PROCESSING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = VaultWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = VaultWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.badbundle.vault.Widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1C4688F82FC8D77F004E2279 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPINTENTS_PACKAGE_DEPENDENCIES = VaultiOSWidgets;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_ENTITLEMENTS = VaultWidgetsExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_APPINTENTS_METADATA_PROCESSING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = VaultWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = VaultWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.5;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.badbundle.vault.Widgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		1CBE0CDA2CD229FF000EA09D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -520,6 +677,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1C4688FA2FC8D77F004E2279 /* Build configuration list for PBXNativeTarget "VaultWidgetsExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1C4688F72FC8D77F004E2279 /* Debug */,
+				1C4688F82FC8D77F004E2279 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		1CBE0CDD2CD229FF000EA09D /* Build configuration list for PBXNativeTarget "VaultAppAutofill" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -550,6 +716,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		1C4688FB2FC8D7E9004E2279 /* VaultiOSWidgets */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = VaultiOSWidgets;
+		};
 		1C58F2F22AE5764100962BAB /* VaultiOS */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = VaultiOS;

--- a/VaultApp/VaultApp/Info.plist
+++ b/VaultApp/VaultApp/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.badbundle.vault</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>vault</string>
+			</array>
+		</dict>
+	</array>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/VaultApp/VaultWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/VaultApp/VaultWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VaultApp/VaultWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/VaultApp/VaultWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VaultApp/VaultWidgets/Assets.xcassets/Contents.json
+++ b/VaultApp/VaultWidgets/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VaultApp/VaultWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/VaultApp/VaultWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/VaultApp/VaultWidgets/Info.plist
+++ b/VaultApp/VaultWidgets/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/VaultApp/VaultWidgets/VaultWidgetsBundle.swift
+++ b/VaultApp/VaultWidgets/VaultWidgetsBundle.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+import VaultiOSWidgets
+import WidgetKit
+
+@main
+struct VaultWidgetsBundle: WidgetBundle {
+    var body: some Widget { OTPWidget() }
+    
+    init() {
+        _ = OTPWidgetIntent.self
+        _ = OTPWidgetItemEntity.self
+    }
+}

--- a/VaultApp/VaultWidgetsExtension.entitlements
+++ b/VaultApp/VaultWidgetsExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.badbundle.vault-group</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- New `VaultWidgets` extension target hosting an opt-in OTP code widget that mirrors the in-app preview tile (icon, issuer/account, monospaced chunked digits, live progress bar).
- Picker only offers items that pass `VaultItemWidgetEligibility` — derived from existing metadata (`lockState == .notLocked`, `visibility == .always`, `searchableLevel != .onlyPassphrase`, `killphrase == nil`). No new schema field, no migration.
- Live timer uses WidgetKit's `ProgressView(timerInterval:countsDown:)` so the bar animates between timeline reloads.
- HOTP support via `vault://otp/{id}/increment` deep link — widget shows last-known counter value; tap opens app and runs the existing increment path.
- Widget timelines reload after any OTP write, HOTP increment, or killphrase deletion via `VaultDataModel.onDataChanged` → `WidgetCenter.reloadAllTimelines()`.

## Architecture

- `VaultiOSShared` (new SPM target): `OTPCodeTextView` digit renderer + `WidgetDeepLink` URL helper. Lightweight so the widget extension reuses them without linking `VaultiOS`.
- `VaultiOSWidgets` (new SPM target): widget entry/snapshot types, `WidgetVaultLoader` reading the shared App Group SwiftData store, `OTPWidgetIntent` with dynamic `AppEntity` picker, `OTPWidgetProvider` building TOTP (two-entry) / HOTP (single-entry) timelines, per-family views for `systemSmall`, `accessoryRectangular`, `accessoryCircular`.
- `VaultSharedStorage` in `VaultFeed`: centralises the App Group ID so any process can resolve the shared SQLite URL.
- `VaultWidgets` app-extension target: thin `WidgetBundle` wrapper. Build settings `APPINTENTS_PACKAGE_DEPENDENCIES = VaultiOSWidgets` and `ENABLE_APPINTENTS_METADATA_PROCESSING = YES` make the metadata extractor scan the SPM module — without them the system renders the widget as `StaticConfiguration` and the "Edit Widget" affordance never appears.

## Manifesto compliance

| Corollary | Compliance |
|---|---|
| C1 No bulk ops | Widget configuration picks one item at a time. |
| C2 No oracle channels | Deleted, missing, and newly-ineligible items render identically as `.unavailable`. Picker silently filters ineligible items. |
| C3 No telemetry | No analytics / logs of secrets in the new code. |
| C4 Device auth ≠ duress gate | Eligibility derives from item state, not auth. Locked items never offered. |
| C5 No enumeration UI | Picker shows only `.always`-visible, unlocked, non-killphrase items — same set already on the main feed. |
| C7 Protective defaults | Feature inert until widget placed + configured. |
| C9 Asymmetric discoverability | Non-duress feature; safe to advertise. Filter invisible to users. |
| C10 Backups | No schema change → backups unaffected. |

## Test plan

- [x] `VaultFeedTests` 722/722 pass, including new `VaultItemWidgetEligibilityTests` (7).
- [x] `VaultiOSWidgetsTests` `WidgetDeepLinkTests` (6) pass.
- [x] `VaultiOSTests` pass including the moved `OTPCodeTextViewSnapshotTests`.
- [x] Manual: add TOTP code with `visibility=.always`, no killphrase. Place small widget on home screen, pick it in config sheet. Verify rendering matches in-app `TOTPCodePreviewView` and bar counts down.
- [x] Manual: wait through period rollover — code value updates.
- [x] Manual: edit item to `visibility=.onlySearch`. Widget shows "unavailable" on next reload. Restore visibility — widget shows code again.
- [x] Manual: add killphrase to a widget-shown item. Widget shows "unavailable".
- [x] Manual: lock an item. Widget shows "unavailable".
- [x] Manual: add HOTP code, place widget, tap. App opens, counter increments, widget reloads with new value.
- [ ] Manual: place `accessoryRectangular` and `accessoryCircular` on lock screen — both render with live progress.
- [ ] Audit new widget/extension code for `print` / `os_log` / analytics emitting secret-bearing strings (C3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
