### PR TITLE
Inject FileManager into rehash pending stores

### DIFF
--- a/Vault/Sources/VaultFeed/Storage/Migration/KillphraseRehashService.swift
+++ b/Vault/Sources/VaultFeed/Storage/Migration/KillphraseRehashService.swift
@@ -21,10 +21,11 @@ public struct KillphraseRehashService: Sendable {
         self.writer = writer
     }
 
-    public init(storeDirectory: URL, writer: @escaping Writer) {
+    public init(storeDirectory: URL, fileManager: FileManager = .default, writer: @escaping Writer) {
         self.init(
             pendingStore: PendingKillphraseRehashStore(
                 fileURL: PendingKillphraseRehashStore.defaultURL(storeDirectory: storeDirectory),
+                fileManager: fileManager,
             ),
             writer: writer,
         )

--- a/Vault/Sources/VaultFeed/Storage/Migration/PendingKillphraseRehashStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/Migration/PendingKillphraseRehashStore.swift
@@ -12,16 +12,24 @@ import Foundation
 ///
 /// The file is cleared (and securely overwritten before deletion) once
 /// all entries have been re-hashed.
-struct PendingKillphraseRehashStore: Sendable {
+///
+/// `FileManager` is documented thread-safe for the basic operations used
+/// here (`fileExists`, `attributesOfItem`, `removeItem`) and the call
+/// sites only ever hop through this struct serially via the rehash
+/// service. Marked `@unchecked Sendable` so the injected dependency does
+/// not force every caller to wrap it.
+struct PendingKillphraseRehashStore: @unchecked Sendable { // swiftlint:disable:this no_unchecked_sendable
     struct Entry: Codable, Equatable, Sendable {
         let itemID: UUID
         let phrase: String
     }
 
     private let fileURL: URL
+    private let fileManager: FileManager
 
-    init(fileURL: URL) {
+    init(fileURL: URL, fileManager: FileManager = .default) {
         self.fileURL = fileURL
+        self.fileManager = fileManager
     }
 
     /// Default location alongside the SwiftData store.
@@ -31,7 +39,7 @@ struct PendingKillphraseRehashStore: Sendable {
 
     /// Read all pending entries. Returns an empty array if no file exists.
     func read() throws -> [Entry] {
-        guard FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
+        guard fileManager.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
             return []
         }
         let data = try Data(contentsOf: fileURL)
@@ -51,15 +59,15 @@ struct PendingKillphraseRehashStore: Sendable {
     /// minimisation; the file system may still retain copies depending on
     /// underlying storage.
     func clear() throws {
-        guard FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
+        guard fileManager.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
             return
         }
-        if let size = try? FileManager.default.attributesOfItem(
+        if let size = try? fileManager.attributesOfItem(
             atPath: fileURL.path(percentEncoded: false),
         )[.size] as? Int, size > 0 {
             let zeros = Data(count: size)
             try? zeros.write(to: fileURL, options: [.atomic])
         }
-        try FileManager.default.removeItem(at: fileURL)
+        try fileManager.removeItem(at: fileURL)
     }
 }

--- a/Vault/Sources/VaultFeed/Storage/Migration/PendingSearchPassphraseRehashStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/Migration/PendingSearchPassphraseRehashStore.swift
@@ -13,16 +13,24 @@ import Foundation
 ///
 /// The file is cleared (and securely overwritten before deletion) once
 /// all entries have been re-hashed.
-struct PendingSearchPassphraseRehashStore: Sendable {
+///
+/// `FileManager` is thread-safe for the basic file operations used here
+/// (`fileExists`, `attributesOfItem`, `removeItem`) and the call sites
+/// only ever hop through this struct serially via the rehash service.
+/// Marked `@unchecked Sendable` so the injected dependency does not force
+/// every caller to wrap it.
+struct PendingSearchPassphraseRehashStore: @unchecked Sendable { // swiftlint:disable:this no_unchecked_sendable
     struct Entry: Codable, Equatable, Sendable {
         let itemID: UUID
         let phrase: String
     }
 
     private let fileURL: URL
+    private let fileManager: FileManager
 
-    init(fileURL: URL) {
+    init(fileURL: URL, fileManager: FileManager = .default) {
         self.fileURL = fileURL
+        self.fileManager = fileManager
     }
 
     /// Default location alongside the SwiftData store.
@@ -32,7 +40,7 @@ struct PendingSearchPassphraseRehashStore: Sendable {
 
     /// Read all pending entries. Returns an empty array if no file exists.
     func read() throws -> [Entry] {
-        guard FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
+        guard fileManager.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
             return []
         }
         let data = try Data(contentsOf: fileURL)
@@ -52,15 +60,15 @@ struct PendingSearchPassphraseRehashStore: Sendable {
     /// minimisation; the file system may still retain copies depending on
     /// underlying storage.
     func clear() throws {
-        guard FileManager.default.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
+        guard fileManager.fileExists(atPath: fileURL.path(percentEncoded: false)) else {
             return
         }
-        if let size = try? FileManager.default.attributesOfItem(
+        if let size = try? fileManager.attributesOfItem(
             atPath: fileURL.path(percentEncoded: false),
         )[.size] as? Int, size > 0 {
             let zeros = Data(count: size)
             try? zeros.write(to: fileURL, options: [.atomic])
         }
-        try FileManager.default.removeItem(at: fileURL)
+        try fileManager.removeItem(at: fileURL)
     }
 }

--- a/Vault/Sources/VaultFeed/Storage/Migration/SearchPassphraseRehashService.swift
+++ b/Vault/Sources/VaultFeed/Storage/Migration/SearchPassphraseRehashService.swift
@@ -21,10 +21,11 @@ public struct SearchPassphraseRehashService: Sendable {
         self.writer = writer
     }
 
-    public init(storeDirectory: URL, writer: @escaping Writer) {
+    public init(storeDirectory: URL, fileManager: FileManager = .default, writer: @escaping Writer) {
         self.init(
             pendingStore: PendingSearchPassphraseRehashStore(
                 fileURL: PendingSearchPassphraseRehashStore.defaultURL(storeDirectory: storeDirectory),
+                fileManager: fileManager,
             ),
             writer: writer,
         )

--- a/Vault/Sources/VaultiOS/VaultRoot.swift
+++ b/Vault/Sources/VaultiOS/VaultRoot.swift
@@ -69,6 +69,7 @@ public enum VaultRoot {
         let store = vaultStore
         return KillphraseRehashService(
             storeDirectory: vaultStorageDirectory,
+            fileManager: fileManager,
             writer: { id, digest in
                 try await store.applyKillphraseDigest(itemID: id, digest: digest)
             },

--- a/Vault/Sources/VaultiOS/VaultRoot.swift
+++ b/Vault/Sources/VaultiOS/VaultRoot.swift
@@ -80,6 +80,7 @@ public enum VaultRoot {
         let store = vaultStore
         return SearchPassphraseRehashService(
             storeDirectory: vaultStorageDirectory,
+            fileManager: fileManager,
             writer: { id, digest in
                 try await store.applySearchPassphraseDigest(itemID: id, digest: digest)
             },


### PR DESCRIPTION
## Summary
Two paired commits that inject `FileManager` into both rehash pending stores.

The pending-rehash stores hard-wired `FileManager.default` for every file operation, blocking tests from substituting an isolated or in-memory file manager. Each constructor now takes a `FileManager` parameter that defaults to `.default`.

- `PendingSearchPassphraseRehashStore(fileURL:fileManager:)` (follow-up to #519)
- `PendingKillphraseRehashStore(fileURL:fileManager:)` (mirroring the same precedent on the killphrase side)

The respective rehash services (`SearchPassphraseRehashService.init(storeDirectory:fileManager:writer:)`, `KillphraseRehashService.init(storeDirectory:fileManager:writer:)`) plumb the same parameter through, and `VaultRoot.makeSearchPassphraseRehashService` / `makeKillphraseRehashService` pass the existing `VaultRoot.fileManager` so the production wiring stays consistent with the rest of the composition root.

Both stores are marked `@unchecked Sendable` (with a swiftlint disable explaining why): `FileManager` is documented thread-safe for the basic operations used here (`fileExists`, `attributesOfItem`, `removeItem`), and each rehash service serialises access through a single `run(using:)` entry point.

## Test plan
- [x] `VaultFeedTests/PendingSearchPassphraseRehashStoreTests` and `SearchPassphraseRehashServiceTests` pass against the injected default
- [x] `VaultFeedTests/PendingKillphraseRehashStoreTests` and `KillphraseRehashServiceTests` pass against the injected default
- [x] `make format && make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
