### PR TITLE
Recover unreadable persisted vault store

### DIFF
--- a/Vault/Sources/TestHelpersMacros/LeakTrackedMacro.swift
+++ b/Vault/Sources/TestHelpersMacros/LeakTrackedMacro.swift
@@ -41,9 +41,9 @@ public struct LeakTrackedMacro: BodyMacro {
 
         let statements = body.statements
         let wrapperCall: ExprSyntax = if isAsync {
-            "try await withLeakTracking { \(statements) }"
+            "try await withLeakTracking { () async throws in \(statements) }"
         } else {
-            "try withLeakTracking { \(statements) }"
+            "try withLeakTracking { () throws in \(statements) }"
         }
 
         return [CodeBlockItemSyntax(item: .expr(wrapperCall))]

--- a/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStoreFactory.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStoreFactory.swift
@@ -2,28 +2,72 @@ import Foundation
 import SwiftData
 
 public final class PersistedLocalVaultStoreFactory {
-    private let storageDirectory: URL
+    private static let storeFilename = "vault-primary.sqlite"
+    private static let storeSidecarSuffixes = ["-shm", "-wal"]
 
-    public init(storageDirectory: URL) {
+    private let storageDirectory: URL
+    private let fileManager: FileManager
+    private let archiveDirectoryName: () -> String
+
+    public init(
+        storageDirectory: URL,
+        fileManager: FileManager = .default,
+        archiveDirectoryName: @escaping () -> String = {
+            let timestamp = ISO8601DateFormatter()
+                .string(from: Date())
+                .replacingOccurrences(of: ":", with: "-")
+            return "vault-primary.failed-open-\(timestamp)"
+        },
+    ) {
         self.storageDirectory = storageDirectory
+        self.fileManager = fileManager
+        self.archiveDirectoryName = archiveDirectoryName
     }
 
     public func makeVaultStore() -> PersistedLocalVaultStore {
+        let storeURL = storageDirectory.appending(path: Self.storeFilename)
         do {
-            let storeURL = storageDirectory.appending(path: "vault-primary.sqlite")
-            let configuration = ModelConfiguration(
-                "PersistedLocalVaultStore",
-                schema: .init(versionedSchema: PersistedSchemaLatestVersion.self),
-                url: storeURL,
-            )
-            let container = try ModelContainer(
-                for: PersistedVaultItem.self, PersistedVaultTag.self,
-                migrationPlan: PersistedSchemaMigrationPlan.self,
-                configurations: configuration,
-            )
-            return PersistedLocalVaultStore(modelContainer: container)
+            return try makeVaultStore(storeURL: storeURL)
         } catch {
-            fatalError("Unable to connect to PersistedLocalVaultStore: \(error)")
+            recoverExistingStoreIfPresent(storeURL: storeURL, connectionError: error)
+            do {
+                return try makeVaultStore(storeURL: storeURL)
+            } catch {
+                fatalError("Unable to connect to PersistedLocalVaultStore after recovery: \(error)")
+            }
+        }
+    }
+
+    private func makeVaultStore(storeURL: URL) throws -> PersistedLocalVaultStore {
+        let configuration = ModelConfiguration(
+            "PersistedLocalVaultStore",
+            schema: .init(versionedSchema: PersistedSchemaLatestVersion.self),
+            url: storeURL,
+        )
+        let container = try ModelContainer(
+            for: PersistedVaultItem.self, PersistedVaultTag.self,
+            migrationPlan: PersistedSchemaMigrationPlan.self,
+            configurations: configuration,
+        )
+        return PersistedLocalVaultStore(modelContainer: container)
+    }
+
+    private func recoverExistingStoreIfPresent(storeURL: URL, connectionError: any Error) {
+        do {
+            let existingURLs = storeBundleURLs(storeURL: storeURL).filter(fileExists(at:))
+            guard existingURLs.isEmpty == false else {
+                fatalError("Unable to connect to PersistedLocalVaultStore: \(connectionError)")
+            }
+
+            let archiveURL = makeUniqueArchiveDirectoryURL()
+            try fileManager.createDirectory(at: archiveURL, withIntermediateDirectories: true)
+
+            for url in existingURLs {
+                let destinationURL = archiveURL.appending(path: url.lastPathComponent)
+                try fileManager.moveItem(at: url, to: destinationURL)
+            }
+        } catch {
+            fatalError("Unable to recover PersistedLocalVaultStore: \(error)")
         }
     }
 
@@ -31,5 +75,35 @@ public final class PersistedLocalVaultStoreFactory {
         var errorDescription: String? {
             "No user document directory available"
         }
+    }
+}
+
+extension PersistedLocalVaultStoreFactory {
+    private func makeUniqueArchiveDirectoryURL() -> URL {
+        let baseName = archiveDirectoryName()
+        var candidateURL = storageDirectory.appending(path: baseName)
+        var suffix = 2
+
+        while fileExists(at: candidateURL) {
+            candidateURL = storageDirectory.appending(path: "\(baseName)-\(suffix)")
+            suffix += 1
+        }
+
+        return candidateURL
+    }
+
+    private func storeBundleURLs(storeURL: URL) -> [URL] {
+        let sidecarURLs = Self.storeSidecarSuffixes.map { suffix in
+            URL(fileURLWithPath: storeURL.path(percentEncoded: false) + suffix)
+        }
+        return [
+            storeURL,
+            PendingKillphraseRehashStore.defaultURL(storeDirectory: storageDirectory),
+            PendingSearchPassphraseRehashStore.defaultURL(storeDirectory: storageDirectory),
+        ] + sidecarURLs
+    }
+
+    private func fileExists(at url: URL) -> Bool {
+        fileManager.fileExists(atPath: url.path(percentEncoded: false))
     }
 }

--- a/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStoreFactory.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStoreFactory.swift
@@ -6,7 +6,8 @@ public final class PersistedLocalVaultStoreFactory {
     private static let storeSidecarSuffixes = ["-shm", "-wal"]
 
     private let storageDirectory: URL
-    private let fileManager: FileManager
+    private let storeOpener: any PersistedLocalVaultStoreOpening
+    private let fileSystem: any PersistedLocalVaultStoreRecoveryFileSystem
     private let archiveDirectoryName: () -> String
 
     public init(
@@ -20,25 +21,96 @@ public final class PersistedLocalVaultStoreFactory {
         },
     ) {
         self.storageDirectory = storageDirectory
-        self.fileManager = fileManager
+        storeOpener = SwiftDataPersistedLocalVaultStoreOpener()
+        fileSystem = FileManagerPersistedLocalVaultStoreRecoveryFileSystem(fileManager: fileManager)
+        self.archiveDirectoryName = archiveDirectoryName
+    }
+
+    init(
+        storageDirectory: URL,
+        storeOpener: any PersistedLocalVaultStoreOpening,
+        fileSystem: any PersistedLocalVaultStoreRecoveryFileSystem,
+        archiveDirectoryName: @escaping () -> String,
+    ) {
+        self.storageDirectory = storageDirectory
+        self.storeOpener = storeOpener
+        self.fileSystem = fileSystem
         self.archiveDirectoryName = archiveDirectoryName
     }
 
     public func makeVaultStore() -> PersistedLocalVaultStore {
+        do {
+            return try makeVaultStoreOrThrow()
+        } catch let StoreConnectionError.unableToConnect(error) {
+            fatalError("Unable to connect to PersistedLocalVaultStore: \(error)")
+        } catch let StoreConnectionError.unableToConnectAfterRecovery(error) {
+            fatalError("Unable to connect to PersistedLocalVaultStore after recovery: \(error)")
+        } catch let StoreConnectionError.unableToRecover(error) {
+            fatalError("Unable to recover PersistedLocalVaultStore: \(error)")
+        } catch {
+            fatalError("Unable to connect to PersistedLocalVaultStore: \(error)")
+        }
+    }
+
+    func makeVaultStoreOrThrow() throws -> PersistedLocalVaultStore {
         let storeURL = storageDirectory.appending(path: Self.storeFilename)
         do {
-            return try makeVaultStore(storeURL: storeURL)
+            return try storeOpener.open(storeURL: storeURL)
         } catch {
-            recoverExistingStoreIfPresent(storeURL: storeURL, connectionError: error)
+            try recoverExistingStoreIfPresent(storeURL: storeURL, connectionError: error)
             do {
-                return try makeVaultStore(storeURL: storeURL)
+                return try storeOpener.open(storeURL: storeURL)
             } catch {
-                fatalError("Unable to connect to PersistedLocalVaultStore after recovery: \(error)")
+                throw StoreConnectionError.unableToConnectAfterRecovery(error)
             }
         }
     }
 
-    private func makeVaultStore(storeURL: URL) throws -> PersistedLocalVaultStore {
+    private func recoverExistingStoreIfPresent(storeURL: URL, connectionError: any Error) throws {
+        do {
+            let existingURLs = storeBundleURLs(storeURL: storeURL).filter { fileExists(at: $0.url) }
+            guard existingURLs.isEmpty == false else {
+                throw StoreConnectionError.unableToConnect(connectionError)
+            }
+
+            let archiveURL = makeUniqueArchiveDirectoryURL()
+            try fileSystem.createDirectory(at: archiveURL)
+
+            for existingURL in existingURLs {
+                let destinationURL = archiveURL.appending(path: existingURL.url.lastPathComponent)
+                do {
+                    try fileSystem.moveItem(at: existingURL.url, to: destinationURL)
+                } catch {
+                    guard fileExists(at: existingURL.url) else { continue }
+                    throw StoreConnectionError.unableToRecover(error)
+                }
+            }
+        } catch let error as StoreConnectionError {
+            throw error
+        } catch {
+            throw StoreConnectionError.unableToRecover(error)
+        }
+    }
+
+    enum StoreConnectionError: Error {
+        case unableToConnect(any Error)
+        case unableToRecover(any Error)
+        case unableToConnectAfterRecovery(any Error)
+    }
+
+    struct NoUserDocumentDirectory: Error, LocalizedError {
+        var errorDescription: String? {
+            "No user document directory available"
+        }
+    }
+}
+
+protocol PersistedLocalVaultStoreOpening {
+    func open(storeURL: URL) throws -> PersistedLocalVaultStore
+}
+
+private struct SwiftDataPersistedLocalVaultStoreOpener: PersistedLocalVaultStoreOpening {
+    func open(storeURL: URL) throws -> PersistedLocalVaultStore {
         let configuration = ModelConfiguration(
             "PersistedLocalVaultStore",
             schema: .init(versionedSchema: PersistedSchemaLatestVersion.self),
@@ -51,30 +123,27 @@ public final class PersistedLocalVaultStoreFactory {
         )
         return PersistedLocalVaultStore(modelContainer: container)
     }
+}
 
-    private func recoverExistingStoreIfPresent(storeURL: URL, connectionError: any Error) {
-        do {
-            let existingURLs = storeBundleURLs(storeURL: storeURL).filter(fileExists(at:))
-            guard existingURLs.isEmpty == false else {
-                fatalError("Unable to connect to PersistedLocalVaultStore: \(connectionError)")
-            }
+protocol PersistedLocalVaultStoreRecoveryFileSystem {
+    func fileExists(at url: URL) -> Bool
+    func createDirectory(at url: URL) throws
+    func moveItem(at sourceURL: URL, to destinationURL: URL) throws
+}
 
-            let archiveURL = makeUniqueArchiveDirectoryURL()
-            try fileManager.createDirectory(at: archiveURL, withIntermediateDirectories: true)
+private struct FileManagerPersistedLocalVaultStoreRecoveryFileSystem: PersistedLocalVaultStoreRecoveryFileSystem {
+    let fileManager: FileManager
 
-            for url in existingURLs {
-                let destinationURL = archiveURL.appending(path: url.lastPathComponent)
-                try fileManager.moveItem(at: url, to: destinationURL)
-            }
-        } catch {
-            fatalError("Unable to recover PersistedLocalVaultStore: \(error)")
-        }
+    func fileExists(at url: URL) -> Bool {
+        fileManager.fileExists(atPath: url.path(percentEncoded: false))
     }
 
-    struct NoUserDocumentDirectory: Error, LocalizedError {
-        var errorDescription: String? {
-            "No user document directory available"
-        }
+    func createDirectory(at url: URL) throws {
+        try fileManager.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    func moveItem(at sourceURL: URL, to destinationURL: URL) throws {
+        try fileManager.moveItem(at: sourceURL, to: destinationURL)
     }
 }
 
@@ -92,18 +161,22 @@ extension PersistedLocalVaultStoreFactory {
         return candidateURL
     }
 
-    private func storeBundleURLs(storeURL: URL) -> [URL] {
+    private func storeBundleURLs(storeURL: URL) -> [RecoveryFile] {
         let sidecarURLs = Self.storeSidecarSuffixes.map { suffix in
             URL(fileURLWithPath: storeURL.path(percentEncoded: false) + suffix)
         }
         return [
-            storeURL,
-            PendingKillphraseRehashStore.defaultURL(storeDirectory: storageDirectory),
-            PendingSearchPassphraseRehashStore.defaultURL(storeDirectory: storageDirectory),
-        ] + sidecarURLs
+            RecoveryFile(url: storeURL),
+            RecoveryFile(url: PendingKillphraseRehashStore.defaultURL(storeDirectory: storageDirectory)),
+            RecoveryFile(url: PendingSearchPassphraseRehashStore.defaultURL(storeDirectory: storageDirectory)),
+        ] + sidecarURLs.map(RecoveryFile.init(url:))
     }
 
     private func fileExists(at url: URL) -> Bool {
-        fileManager.fileExists(atPath: url.path(percentEncoded: false))
+        fileSystem.fileExists(at: url)
+    }
+
+    private struct RecoveryFile {
+        let url: URL
     }
 }

--- a/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStoreFactory.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStoreFactory.swift
@@ -9,6 +9,7 @@ public final class PersistedLocalVaultStoreFactory {
     private let storeOpener: any PersistedLocalVaultStoreOpening
     private let fileSystem: any PersistedLocalVaultStoreRecoveryFileSystem
     private let archiveDirectoryName: () -> String
+    private let failureHandler: (String) -> PersistedLocalVaultStore
 
     public init(
         storageDirectory: URL,
@@ -24,6 +25,7 @@ public final class PersistedLocalVaultStoreFactory {
         storeOpener = SwiftDataPersistedLocalVaultStoreOpener()
         fileSystem = FileManagerPersistedLocalVaultStoreRecoveryFileSystem(fileManager: fileManager)
         self.archiveDirectoryName = archiveDirectoryName
+        failureHandler = { fatalError($0) }
     }
 
     init(
@@ -31,24 +33,26 @@ public final class PersistedLocalVaultStoreFactory {
         storeOpener: any PersistedLocalVaultStoreOpening,
         fileSystem: any PersistedLocalVaultStoreRecoveryFileSystem,
         archiveDirectoryName: @escaping () -> String,
+        failureHandler: @escaping (String) -> PersistedLocalVaultStore = { fatalError($0) },
     ) {
         self.storageDirectory = storageDirectory
         self.storeOpener = storeOpener
         self.fileSystem = fileSystem
         self.archiveDirectoryName = archiveDirectoryName
+        self.failureHandler = failureHandler
     }
 
     public func makeVaultStore() -> PersistedLocalVaultStore {
         do {
             return try makeVaultStoreOrThrow()
         } catch let StoreConnectionError.unableToConnect(error) {
-            fatalError("Unable to connect to PersistedLocalVaultStore: \(error)")
+            return failureHandler("Unable to connect to PersistedLocalVaultStore: \(error)")
         } catch let StoreConnectionError.unableToConnectAfterRecovery(error) {
-            fatalError("Unable to connect to PersistedLocalVaultStore after recovery: \(error)")
+            return failureHandler("Unable to connect to PersistedLocalVaultStore after recovery: \(error)")
         } catch let StoreConnectionError.unableToRecover(error) {
-            fatalError("Unable to recover PersistedLocalVaultStore: \(error)")
+            return failureHandler("Unable to recover PersistedLocalVaultStore: \(error)")
         } catch {
-            fatalError("Unable to connect to PersistedLocalVaultStore: \(error)")
+            return failureHandler("Unable to connect to PersistedLocalVaultStore: \(error)")
         }
     }
 

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftData
 import Testing
 @testable import VaultFeed
 
@@ -18,24 +19,48 @@ struct PersistedLocalVaultStoreFactoryTests {
 
         let result = try await store.retrieve(query: .init())
         #expect(result == .empty())
-        #expect(FileManager.default.fileExists(atPath: archiveURL.path(percentEncoded: false)) == false)
+        #expect(fileExists(at: archiveURL) == false)
+    }
+
+    @Test
+    func makeVaultStore_preservesExistingValidStoreContentsAcrossReopen() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let factory = PersistedLocalVaultStoreFactory(
+            storageDirectory: directory,
+            archiveDirectoryName: { "failed-store" },
+        )
+        var openedStore: PersistedLocalVaultStore? = factory.makeVaultStore()
+        let item = uniqueVaultItem().makeWritable()
+        let itemID = try await #require(openedStore).insert(item: item)
+        openedStore = nil
+
+        let reopenedStore = factory.makeVaultStore()
+        let result = try await reopenedStore.retrieve(query: .init())
+
+        #expect(result.items.map(\.id).contains(itemID))
+        #expect(fileExists(at: directory.appending(path: "failed-store")) == false)
     }
 
     @Test
     func makeVaultStore_archivesUnreadableExistingStoreThenCreatesFreshStore() async throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
-        let storeURL = directory.appending(path: "vault-primary.sqlite")
-        let walURL = sidecarURL(for: storeURL, suffix: "-wal")
-        let shmURL = sidecarURL(for: storeURL, suffix: "-shm")
-        let pendingKillphraseURL = directory.appending(path: "vault-primary.pending-killphrase-rehash.json")
-        let pendingSearchPassphraseURL = directory
-            .appending(path: "vault-primary.pending-search-passphrase-rehash.json")
-        try Data("not a sqlite store".utf8).write(to: storeURL)
-        try Data("wal".utf8).write(to: walURL)
-        try Data("shm".utf8).write(to: shmURL)
-        try Data("[]".utf8).write(to: pendingKillphraseURL)
-        try Data("[]".utf8).write(to: pendingSearchPassphraseURL)
+        let storeURL = url(for: .primary, in: directory)
+        let pendingKillphraseURL = url(for: .pendingKillphrase, in: directory)
+        let pendingSearchPassphraseURL = url(for: .pendingSearchPassphrase, in: directory)
+        let corruptData = Data("not a sqlite store".utf8)
+        let pendingKillphraseData = Data("[{\"itemID\":\"00000000-0000-0000-0000-000000000001\",\"phrase\":\"one\"}]"
+            .utf8)
+        let pendingSearchPassphraseData = Data(
+            "[{\"itemID\":\"00000000-0000-0000-0000-000000000002\",\"phrase\":\"two\"}]"
+                .utf8,
+        )
+        try corruptData.write(to: storeURL)
+        try Data("wal".utf8).write(to: url(for: .wal, in: directory))
+        try Data("shm".utf8).write(to: url(for: .shm, in: directory))
+        try pendingKillphraseData.write(to: pendingKillphraseURL)
+        try pendingSearchPassphraseData.write(to: pendingSearchPassphraseURL)
         let archiveURL = directory.appending(path: "failed-store")
         let sut = PersistedLocalVaultStoreFactory(
             storageDirectory: directory,
@@ -43,37 +68,432 @@ struct PersistedLocalVaultStoreFactoryTests {
         )
 
         let store = sut.makeVaultStore()
+        let itemID = try await store.insert(item: uniqueVaultItem().makeWritable())
+        let reopenedStore = PersistedLocalVaultStoreFactory(
+            storageDirectory: directory,
+            archiveDirectoryName: { "unused" },
+        ).makeVaultStore()
+        let result = try await reopenedStore.retrieve(query: .init())
 
-        let result = try await store.retrieve(query: .init())
-        #expect(result == .empty())
-        #expect(FileManager.default
-            .fileExists(atPath: archiveURL.appending(path: storeURL.lastPathComponent).path(percentEncoded: false)))
-        #expect(FileManager.default
-            .fileExists(atPath: archiveURL.appending(path: walURL.lastPathComponent).path(percentEncoded: false)))
-        #expect(FileManager.default
-            .fileExists(atPath: archiveURL.appending(path: shmURL.lastPathComponent).path(percentEncoded: false)))
+        #expect(result.items.map(\.id).contains(itemID))
+        #expect(try Data(contentsOf: archiveURL.appending(path: storeURL.lastPathComponent)) == corruptData)
+        #expect(try Data(contentsOf: archiveURL.appending(path: pendingKillphraseURL.lastPathComponent)) ==
+            pendingKillphraseData)
         #expect(
-            FileManager.default.fileExists(
-                atPath: archiveURL.appending(path: pendingKillphraseURL.lastPathComponent).path(percentEncoded: false),
-            ),
+            try Data(contentsOf: archiveURL.appending(path: pendingSearchPassphraseURL.lastPathComponent))
+                == pendingSearchPassphraseData,
         )
-        #expect(
-            FileManager.default.fileExists(
-                atPath: archiveURL.appending(path: pendingSearchPassphraseURL.lastPathComponent)
-                    .path(percentEncoded: false),
-            ),
-        )
-        #expect(FileManager.default.fileExists(atPath: pendingKillphraseURL.path(percentEncoded: false)) == false)
-        #expect(FileManager.default.fileExists(atPath: pendingSearchPassphraseURL.path(percentEncoded: false)) == false)
+        #expect(fileExists(at: pendingKillphraseURL) == false)
+        #expect(fileExists(at: pendingSearchPassphraseURL) == false)
     }
 
-    private func makeTemporaryDirectory() throws -> URL {
-        let url = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
-        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
-        return url
+    @Test
+    func makeVaultStoreOrThrow_doesNotRecoverWhenInitialOpenSucceeds() throws {
+        let directory = makeDirectoryURL()
+        let storeURL = url(for: .primary, in: directory)
+        let fileSystem = FakeRecoveryFileSystem(existingFiles: [storeURL])
+        let opener = ScriptedStoreOpener(results: [.success])
+        let sut = makeSUT(directory: directory, opener: opener, fileSystem: fileSystem)
+
+        _ = try sut.makeVaultStoreOrThrow()
+
+        #expect(opener.openedStoreURLs == [storeURL])
+        #expect(fileSystem.createdDirectories == [])
+        #expect(fileSystem.movedItems.isEmpty)
     }
 
-    private func sidecarURL(for storeURL: URL, suffix: String) -> URL {
-        URL(fileURLWithPath: storeURL.path(percentEncoded: false) + suffix)
+    @Test
+    func makeVaultStoreOrThrow_failsWithoutRecoveryWhenInitialOpenFailsAndNoActiveFilesExist() {
+        let directory = makeDirectoryURL()
+        let opener = ScriptedStoreOpener(results: [.failure(FactoryTestError.initialOpen)])
+        let fileSystem = FakeRecoveryFileSystem()
+        let sut = makeSUT(directory: directory, opener: opener, fileSystem: fileSystem)
+
+        expectStoreConnectionError(.unableToConnect) {
+            _ = try sut.makeVaultStoreOrThrow()
+        }
+
+        #expect(opener.openedStoreURLs == [url(for: .primary, in: directory)])
+        #expect(fileSystem.createdDirectories == [])
+        #expect(fileSystem.movedItems.isEmpty)
     }
+
+    @Test(arguments: ActiveFileScenario.all)
+    func makeVaultStoreOrThrow_archivesActiveFileCombinations(_ scenario: ActiveFileScenario) throws {
+        let directory = makeDirectoryURL()
+        let archiveURL = directory.appending(path: "failed-store")
+        let activeURLs = Set(scenario.files.map { url(for: $0, in: directory) })
+        let fileSystem = FakeRecoveryFileSystem(existingFiles: activeURLs)
+        let opener = ScriptedStoreOpener(results: [.failure(FactoryTestError.initialOpen), .success])
+        let sut = makeSUT(directory: directory, opener: opener, fileSystem: fileSystem)
+
+        _ = try sut.makeVaultStoreOrThrow()
+
+        #expect(fileSystem.createdDirectories == [archiveURL])
+        #expect(Set(fileSystem.movedItems.map(\.sourceURL)) == activeURLs)
+        #expect(Set(fileSystem.movedItems.map(\.destinationURL)) ==
+            Set(activeURLs.map { archiveURL.appending(path: $0.lastPathComponent) }))
+        #expect(opener.openedStoreURLs == [url(for: .primary, in: directory), url(for: .primary, in: directory)])
+    }
+
+    @Test(arguments: [
+        ArchiveNameScenario(existingDirectories: [], expectedName: "failed-store"),
+        ArchiveNameScenario(existingDirectories: ["failed-store"], expectedName: "failed-store-2"),
+        ArchiveNameScenario(existingDirectories: ["failed-store", "failed-store-2"], expectedName: "failed-store-3"),
+    ])
+    func makeVaultStoreOrThrow_usesUniqueArchiveDirectory(_ scenario: ArchiveNameScenario) throws {
+        let directory = makeDirectoryURL()
+        let existingDirectories = Set(scenario.existingDirectories.map { directory.appending(path: $0) })
+        let fileSystem = FakeRecoveryFileSystem(
+            existingFiles: [url(for: .primary, in: directory)],
+            existingDirectories: existingDirectories,
+        )
+        let opener = ScriptedStoreOpener(results: [.failure(FactoryTestError.initialOpen), .success])
+        let sut = makeSUT(directory: directory, opener: opener, fileSystem: fileSystem)
+
+        _ = try sut.makeVaultStoreOrThrow()
+
+        let expectedArchiveURL = directory.appending(path: scenario.expectedName)
+        #expect(fileSystem.createdDirectories == [expectedArchiveURL])
+        #expect(fileSystem.movedItems.map(\.destinationURL) == [
+            expectedArchiveURL.appending(path: url(for: .primary, in: directory).lastPathComponent),
+        ])
+    }
+
+    @Test(arguments: DisappearingFileScenario.all)
+    func makeVaultStoreOrThrow_continuesWhenFileDisappearsDuringRecovery(_ scenario: DisappearingFileScenario) throws {
+        let directory = makeDirectoryURL()
+        let disappearingURL = url(for: scenario.disappearingFile, in: directory)
+        let fileSystem = FakeRecoveryFileSystem(
+            existingFiles: Set(scenario.existingFiles.map { url(for: $0, in: directory) }),
+            disappearingFiles: [disappearingURL],
+        )
+        let opener = ScriptedStoreOpener(results: [.failure(FactoryTestError.initialOpen), .success])
+        let sut = makeSUT(directory: directory, opener: opener, fileSystem: fileSystem)
+
+        _ = try sut.makeVaultStoreOrThrow()
+
+        #expect(fileSystem.createdDirectories == [directory.appending(path: "failed-store")])
+        #expect(fileSystem.movedItems.map(\.sourceURL) == scenario.movedFiles.map { url(for: $0, in: directory) })
+        #expect(opener.openedStoreURLs.count == 2)
+    }
+
+    @Test
+    func makeVaultStoreOrThrow_failsWhenArchiveDirectoryCannotBeCreated() {
+        let directory = makeDirectoryURL()
+        let fileSystem = FakeRecoveryFileSystem(
+            existingFiles: [url(for: .primary, in: directory)],
+            createDirectoryError: FactoryTestError.createDirectory,
+        )
+        let opener = ScriptedStoreOpener(results: [.failure(FactoryTestError.initialOpen), .success])
+        let sut = makeSUT(directory: directory, opener: opener, fileSystem: fileSystem)
+
+        expectStoreConnectionError(.unableToRecover) {
+            _ = try sut.makeVaultStoreOrThrow()
+        }
+
+        #expect(opener.openedStoreURLs.count == 1)
+        #expect(fileSystem.movedItems.isEmpty)
+    }
+
+    @Test(arguments: LiveMoveFailureScenario.all)
+    func makeVaultStoreOrThrow_failsWhenLiveFileCannotBeMoved(_ scenario: LiveMoveFailureScenario) {
+        let directory = makeDirectoryURL()
+        let failingURL = url(for: scenario.failingFile, in: directory)
+        let fileSystem = FakeRecoveryFileSystem(
+            existingFiles: Set(scenario.existingFiles.map { url(for: $0, in: directory) }),
+            moveErrors: [failingURL: FactoryTestError.move],
+        )
+        let opener = ScriptedStoreOpener(results: [.failure(FactoryTestError.initialOpen), .success])
+        let sut = makeSUT(directory: directory, opener: opener, fileSystem: fileSystem)
+
+        expectStoreConnectionError(.unableToRecover) {
+            _ = try sut.makeVaultStoreOrThrow()
+        }
+
+        #expect(opener.openedStoreURLs.count == 1)
+        #expect(fileSystem.fileExists(at: failingURL))
+    }
+
+    @Test
+    func makeVaultStoreOrThrow_failsWhenRecoverySucceedsButRetryOpenFails() {
+        let directory = makeDirectoryURL()
+        let primaryURL = url(for: .primary, in: directory)
+        let fileSystem = FakeRecoveryFileSystem(existingFiles: [primaryURL])
+        let opener = ScriptedStoreOpener(results: [
+            .failure(FactoryTestError.initialOpen),
+            .failure(FactoryTestError.retryOpen),
+        ])
+        let sut = makeSUT(directory: directory, opener: opener, fileSystem: fileSystem)
+
+        expectStoreConnectionError(.unableToConnectAfterRecovery) {
+            _ = try sut.makeVaultStoreOrThrow()
+        }
+
+        #expect(fileSystem.movedItems.map(\.sourceURL) == [primaryURL])
+        #expect(opener.openedStoreURLs.count == 2)
+    }
+}
+
+enum StoreFile: Sendable {
+    case primary
+    case wal
+    case shm
+    case pendingKillphrase
+    case pendingSearchPassphrase
+}
+
+struct ActiveFileScenario: Sendable, CustomStringConvertible {
+    let description: String
+    let files: [StoreFile]
+
+    static let all: [Self] = [
+        .init(description: "primary only", files: [.primary]),
+        .init(description: "primary and WAL", files: [.primary, .wal]),
+        .init(description: "primary and SHM", files: [.primary, .shm]),
+        .init(description: "primary and sidecars", files: [.primary, .wal, .shm]),
+        .init(description: "primary and pending killphrase", files: [.primary, .pendingKillphrase]),
+        .init(description: "primary and pending search passphrase", files: [.primary, .pendingSearchPassphrase]),
+        .init(
+            description: "primary and both pending files",
+            files: [.primary, .pendingKillphrase, .pendingSearchPassphrase],
+        ),
+        .init(description: "sidecars and pending files without primary", files: [
+            .wal,
+            .shm,
+            .pendingKillphrase,
+            .pendingSearchPassphrase,
+        ]),
+    ]
+}
+
+struct ArchiveNameScenario: Sendable {
+    let existingDirectories: [String]
+    let expectedName: String
+}
+
+struct DisappearingFileScenario: Sendable, CustomStringConvertible {
+    let description: String
+    let existingFiles: [StoreFile]
+    let disappearingFile: StoreFile
+    let movedFiles: [StoreFile]
+
+    static let all: [Self] = [
+        .init(description: "primary disappears", existingFiles: [.primary], disappearingFile: .primary, movedFiles: []),
+        .init(
+            description: "WAL disappears",
+            existingFiles: [.primary, .wal],
+            disappearingFile: .wal,
+            movedFiles: [.primary],
+        ),
+        .init(
+            description: "SHM disappears",
+            existingFiles: [.primary, .shm],
+            disappearingFile: .shm,
+            movedFiles: [.primary],
+        ),
+        .init(
+            description: "pending killphrase disappears",
+            existingFiles: [.primary, .pendingKillphrase],
+            disappearingFile: .pendingKillphrase,
+            movedFiles: [.primary],
+        ),
+        .init(
+            description: "pending search passphrase disappears",
+            existingFiles: [.primary, .pendingSearchPassphrase],
+            disappearingFile: .pendingSearchPassphrase,
+            movedFiles: [.primary],
+        ),
+    ]
+}
+
+struct LiveMoveFailureScenario: Sendable, CustomStringConvertible {
+    let description: String
+    let existingFiles: [StoreFile]
+    let failingFile: StoreFile
+
+    static let all: [Self] = [
+        .init(description: "primary move fails", existingFiles: [.primary], failingFile: .primary),
+        .init(description: "WAL move fails", existingFiles: [.primary, .wal], failingFile: .wal),
+        .init(description: "SHM move fails", existingFiles: [.primary, .shm], failingFile: .shm),
+        .init(
+            description: "pending killphrase move fails",
+            existingFiles: [.primary, .pendingKillphrase],
+            failingFile: .pendingKillphrase,
+        ),
+        .init(
+            description: "pending search passphrase move fails",
+            existingFiles: [.primary, .pendingSearchPassphrase],
+            failingFile: .pendingSearchPassphrase,
+        ),
+    ]
+}
+
+private enum StoreConnectionErrorCase {
+    case unableToConnect
+    case unableToRecover
+    case unableToConnectAfterRecovery
+}
+
+private enum FactoryTestError: Error {
+    case initialOpen
+    case retryOpen
+    case createDirectory
+    case move
+    case missingFile
+}
+
+private final class ScriptedStoreOpener: PersistedLocalVaultStoreOpening {
+    enum Result {
+        case success
+        case failure(any Error)
+    }
+
+    private var results: [Result]
+    private(set) var openedStoreURLs: [URL] = []
+
+    init(results: [Result]) {
+        self.results = results
+    }
+
+    func open(storeURL: URL) throws -> PersistedLocalVaultStore {
+        openedStoreURLs.append(storeURL)
+        guard results.isEmpty == false else { return try Self.makeInMemoryStore() }
+
+        switch results.removeFirst() {
+        case .success:
+            return try Self.makeInMemoryStore()
+        case let .failure(error):
+            throw error
+        }
+    }
+
+    private static func makeInMemoryStore() throws -> PersistedLocalVaultStore {
+        let container = try ModelContainer(
+            for: PersistedVaultItem.self,
+            configurations: .init(isStoredInMemoryOnly: true),
+        )
+        return PersistedLocalVaultStore(modelContainer: container)
+    }
+}
+
+private final class FakeRecoveryFileSystem: PersistedLocalVaultStoreRecoveryFileSystem {
+    private var existingFiles: Set<String>
+    private var existingDirectories: Set<String>
+    private let disappearingFiles: Set<String>
+    private let createDirectoryError: (any Error)?
+    private let moveErrors: [String: any Error]
+    private(set) var createdDirectories: [URL] = []
+    private(set) var movedItems: [(sourceURL: URL, destinationURL: URL)] = []
+
+    init(
+        existingFiles: Set<URL> = [],
+        existingDirectories: Set<URL> = [],
+        disappearingFiles: Set<URL> = [],
+        createDirectoryError: (any Error)? = nil,
+        moveErrors: [URL: any Error] = [:],
+    ) {
+        self.existingFiles = Set(existingFiles.map(key(for:)))
+        self.existingDirectories = Set(existingDirectories.map(key(for:)))
+        self.disappearingFiles = Set(disappearingFiles.map(key(for:)))
+        self.createDirectoryError = createDirectoryError
+        self.moveErrors = Dictionary(uniqueKeysWithValues: moveErrors.map { (key(for: $0.key), $0.value) })
+    }
+
+    func fileExists(at url: URL) -> Bool {
+        existingFiles.contains(key(for: url)) || existingDirectories.contains(key(for: url))
+    }
+
+    func createDirectory(at url: URL) throws {
+        if let createDirectoryError {
+            throw createDirectoryError
+        }
+        createdDirectories.append(url)
+        existingDirectories.insert(key(for: url))
+    }
+
+    func moveItem(at sourceURL: URL, to destinationURL: URL) throws {
+        let sourceKey = key(for: sourceURL)
+        if disappearingFiles.contains(sourceKey) {
+            existingFiles.remove(sourceKey)
+            throw FactoryTestError.missingFile
+        }
+        if let error = moveErrors[sourceKey] {
+            throw error
+        }
+        guard existingFiles.remove(sourceKey) != nil else {
+            throw FactoryTestError.missingFile
+        }
+
+        movedItems.append((sourceURL, destinationURL))
+        existingFiles.insert(key(for: destinationURL))
+    }
+}
+
+private func makeSUT(
+    directory: URL,
+    opener: ScriptedStoreOpener,
+    fileSystem: FakeRecoveryFileSystem,
+    archiveDirectoryName: @escaping () -> String = { "failed-store" },
+) -> PersistedLocalVaultStoreFactory {
+    PersistedLocalVaultStoreFactory(
+        storageDirectory: directory,
+        storeOpener: opener,
+        fileSystem: fileSystem,
+        archiveDirectoryName: archiveDirectoryName,
+    )
+}
+
+private func expectStoreConnectionError(
+    _ expected: StoreConnectionErrorCase,
+    performing operation: () throws -> Void,
+) {
+    do {
+        try operation()
+        Issue.record("Expected \(expected)")
+    } catch let error as PersistedLocalVaultStoreFactory.StoreConnectionError {
+        switch (expected, error) {
+        case (.unableToConnect, .unableToConnect),
+             (.unableToRecover, .unableToRecover),
+             (.unableToConnectAfterRecovery, .unableToConnectAfterRecovery):
+            break
+        default:
+            Issue.record("Expected \(expected), got \(error)")
+        }
+    } catch {
+        Issue.record("Expected \(expected), got \(error)")
+    }
+}
+
+private func makeTemporaryDirectory() throws -> URL {
+    let url = makeDirectoryURL()
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+private func makeDirectoryURL() -> URL {
+    FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+}
+
+private func url(for file: StoreFile, in directory: URL) -> URL {
+    switch file {
+    case .primary:
+        directory.appending(path: "vault-primary.sqlite")
+    case .wal:
+        URL(fileURLWithPath: url(for: .primary, in: directory).path(percentEncoded: false) + "-wal")
+    case .shm:
+        URL(fileURLWithPath: url(for: .primary, in: directory).path(percentEncoded: false) + "-shm")
+    case .pendingKillphrase:
+        directory.appending(path: "vault-primary.pending-killphrase-rehash.json")
+    case .pendingSearchPassphrase:
+        directory.appending(path: "vault-primary.pending-search-passphrase-rehash.json")
+    }
+}
+
+private func fileExists(at url: URL) -> Bool {
+    FileManager.default.fileExists(atPath: url.path(percentEncoded: false))
+}
+
+private func key(for url: URL) -> String {
+    url.path(percentEncoded: false)
 }

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
@@ -47,9 +47,13 @@ struct PersistedLocalVaultStoreFactoryTests {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let storeURL = url(for: .primary, in: directory)
+        let walURL = url(for: .wal, in: directory)
+        let shmURL = url(for: .shm, in: directory)
         let pendingKillphraseURL = url(for: .pendingKillphrase, in: directory)
         let pendingSearchPassphraseURL = url(for: .pendingSearchPassphrase, in: directory)
         let corruptData = Data("not a sqlite store".utf8)
+        let walData = Data("wal".utf8)
+        let shmData = Data("shm".utf8)
         let pendingKillphraseData = Data("[{\"itemID\":\"00000000-0000-0000-0000-000000000001\",\"phrase\":\"one\"}]"
             .utf8)
         let pendingSearchPassphraseData = Data(
@@ -57,8 +61,8 @@ struct PersistedLocalVaultStoreFactoryTests {
                 .utf8,
         )
         try corruptData.write(to: storeURL)
-        try Data("wal".utf8).write(to: url(for: .wal, in: directory))
-        try Data("shm".utf8).write(to: url(for: .shm, in: directory))
+        try walData.write(to: walURL)
+        try shmData.write(to: shmURL)
         try pendingKillphraseData.write(to: pendingKillphraseURL)
         try pendingSearchPassphraseData.write(to: pendingSearchPassphraseURL)
         let archiveURL = directory.appending(path: "failed-store")
@@ -77,6 +81,8 @@ struct PersistedLocalVaultStoreFactoryTests {
 
         #expect(result.items.map(\.id).contains(itemID))
         #expect(try Data(contentsOf: archiveURL.appending(path: storeURL.lastPathComponent)) == corruptData)
+        #expect(try Data(contentsOf: archiveURL.appending(path: walURL.lastPathComponent)) == walData)
+        #expect(try Data(contentsOf: archiveURL.appending(path: shmURL.lastPathComponent)) == shmData)
         #expect(try Data(contentsOf: archiveURL.appending(path: pendingKillphraseURL.lastPathComponent)) ==
             pendingKillphraseData)
         #expect(
@@ -85,6 +91,30 @@ struct PersistedLocalVaultStoreFactoryTests {
         )
         #expect(fileExists(at: pendingKillphraseURL) == false)
         #expect(fileExists(at: pendingSearchPassphraseURL) == false)
+    }
+
+    @Test
+    func makeVaultStore_archivesUnreadableStoreIntoNextUniqueDirectoryWhenArchiveExists() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = url(for: .primary, in: directory)
+        let corruptData = Data("not a sqlite store".utf8)
+        try corruptData.write(to: storeURL)
+        try FileManager.default.createDirectory(
+            at: directory.appending(path: "failed-store"),
+            withIntermediateDirectories: true,
+        )
+        let sut = PersistedLocalVaultStoreFactory(
+            storageDirectory: directory,
+            archiveDirectoryName: { "failed-store" },
+        )
+
+        let store = sut.makeVaultStore()
+        let result = try await store.retrieve(query: .init())
+
+        let archiveURL = directory.appending(path: "failed-store-2")
+        #expect(result == .empty())
+        #expect(try Data(contentsOf: archiveURL.appending(path: storeURL.lastPathComponent)) == corruptData)
     }
 
     @Test
@@ -100,6 +130,37 @@ struct PersistedLocalVaultStoreFactoryTests {
         #expect(opener.openedStoreURLs == [storeURL])
         #expect(fileSystem.createdDirectories == [])
         #expect(fileSystem.movedItems.isEmpty)
+    }
+
+    @Test(arguments: FatalMessageScenario.all)
+    func makeVaultStore_routesUnrecoverableFailuresThroughFatalMessage(_ scenario: FatalMessageScenario) throws {
+        let directory = makeDirectoryURL()
+        let primaryURL = url(for: .primary, in: directory)
+        let fileSystem = switch scenario.failure {
+        case .noActiveFiles:
+            FakeRecoveryFileSystem()
+        case .createDirectory:
+            FakeRecoveryFileSystem(
+                existingFiles: [primaryURL],
+                createDirectoryError: FactoryTestError.createDirectory,
+            )
+        case .retryOpen:
+            FakeRecoveryFileSystem(existingFiles: [primaryURL])
+        }
+        let opener = ScriptedStoreOpener(results: scenario.openResults)
+        let recorder = try FailureRecorder()
+        let sut = makeSUT(
+            directory: directory,
+            opener: opener,
+            fileSystem: fileSystem,
+            failureHandler: recorder.record,
+        )
+
+        _ = sut.makeVaultStore()
+
+        #expect(recorder.messages.count == 1)
+        #expect(recorder.messages.first?.hasPrefix(scenario.expectedPrefix) == true)
+        #expect(recorder.messages.first?.contains(scenario.expectedErrorDescription) == true)
     }
 
     @Test
@@ -272,6 +333,47 @@ struct ArchiveNameScenario: Sendable {
     let expectedName: String
 }
 
+struct FatalMessageScenario: Sendable, CustomStringConvertible {
+    enum Failure: Sendable {
+        case noActiveFiles
+        case createDirectory
+        case retryOpen
+    }
+
+    let description: String
+    let failure: Failure
+    let openResults: [ScriptedStoreOpener.Result]
+    let expectedPrefix: String
+    let expectedErrorDescription: String
+
+    static let all: [Self] = [
+        .init(
+            description: "initial open fails with no active files",
+            failure: .noActiveFiles,
+            openResults: [.failure(FactoryTestError.initialOpen)],
+            expectedPrefix: "Unable to connect to PersistedLocalVaultStore:",
+            expectedErrorDescription: "initialOpen",
+        ),
+        .init(
+            description: "archive directory creation fails",
+            failure: .createDirectory,
+            openResults: [.failure(FactoryTestError.initialOpen)],
+            expectedPrefix: "Unable to recover PersistedLocalVaultStore:",
+            expectedErrorDescription: "createDirectory",
+        ),
+        .init(
+            description: "retry open fails after recovery",
+            failure: .retryOpen,
+            openResults: [
+                .failure(FactoryTestError.initialOpen),
+                .failure(FactoryTestError.retryOpen),
+            ],
+            expectedPrefix: "Unable to connect to PersistedLocalVaultStore after recovery:",
+            expectedErrorDescription: "retryOpen",
+        ),
+    ]
+}
+
 struct DisappearingFileScenario: Sendable, CustomStringConvertible {
     let description: String
     let existingFiles: [StoreFile]
@@ -335,7 +437,7 @@ private enum StoreConnectionErrorCase {
     case unableToConnectAfterRecovery
 }
 
-private enum FactoryTestError: Error {
+private enum FactoryTestError: Error, Sendable {
     case initialOpen
     case retryOpen
     case createDirectory
@@ -343,10 +445,10 @@ private enum FactoryTestError: Error {
     case missingFile
 }
 
-private final class ScriptedStoreOpener: PersistedLocalVaultStoreOpening {
-    enum Result {
+final class ScriptedStoreOpener: PersistedLocalVaultStoreOpening {
+    enum Result: Sendable {
         case success
-        case failure(any Error)
+        case failure(any Error & Sendable)
     }
 
     private var results: [Result]
@@ -358,22 +460,28 @@ private final class ScriptedStoreOpener: PersistedLocalVaultStoreOpening {
 
     func open(storeURL: URL) throws -> PersistedLocalVaultStore {
         openedStoreURLs.append(storeURL)
-        guard results.isEmpty == false else { return try Self.makeInMemoryStore() }
+        guard results.isEmpty == false else { return try makeInMemoryStore() }
 
         switch results.removeFirst() {
         case .success:
-            return try Self.makeInMemoryStore()
+            return try makeInMemoryStore()
         case let .failure(error):
             throw error
         }
     }
+}
 
-    private static func makeInMemoryStore() throws -> PersistedLocalVaultStore {
-        let container = try ModelContainer(
-            for: PersistedVaultItem.self,
-            configurations: .init(isStoredInMemoryOnly: true),
-        )
-        return PersistedLocalVaultStore(modelContainer: container)
+private final class FailureRecorder {
+    private let fallbackStore: PersistedLocalVaultStore
+    private(set) var messages: [String] = []
+
+    init() throws {
+        fallbackStore = try makeInMemoryStore()
+    }
+
+    func record(_ message: String) -> PersistedLocalVaultStore {
+        messages.append(message)
+        return fallbackStore
     }
 }
 
@@ -435,12 +543,14 @@ private func makeSUT(
     opener: ScriptedStoreOpener,
     fileSystem: FakeRecoveryFileSystem,
     archiveDirectoryName: @escaping () -> String = { "failed-store" },
+    failureHandler: @escaping (String) -> PersistedLocalVaultStore = { fatalError($0) },
 ) -> PersistedLocalVaultStoreFactory {
     PersistedLocalVaultStoreFactory(
         storageDirectory: directory,
         storeOpener: opener,
         fileSystem: fileSystem,
         archiveDirectoryName: archiveDirectoryName,
+        failureHandler: failureHandler,
     )
 }
 
@@ -469,6 +579,14 @@ private func makeTemporaryDirectory() throws -> URL {
     let url = makeDirectoryURL()
     try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
     return url
+}
+
+private func makeInMemoryStore() throws -> PersistedLocalVaultStore {
+    let container = try ModelContainer(
+        for: PersistedVaultItem.self,
+        configurations: .init(isStoredInMemoryOnly: true),
+    )
+    return PersistedLocalVaultStore(modelContainer: container)
 }
 
 private func makeDirectoryURL() -> URL {

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import VaultFeed
+
+@Suite
+struct PersistedLocalVaultStoreFactoryTests {
+    @Test
+    func makeVaultStore_createsEmptyStoreWhenNoExistingStoreExists() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let archiveURL = directory.appending(path: "failed-store")
+        let sut = PersistedLocalVaultStoreFactory(
+            storageDirectory: directory,
+            archiveDirectoryName: { "failed-store" },
+        )
+
+        let store = sut.makeVaultStore()
+
+        let result = try await store.retrieve(query: .init())
+        #expect(result == .empty())
+        #expect(FileManager.default.fileExists(atPath: archiveURL.path(percentEncoded: false)) == false)
+    }
+
+    @Test
+    func makeVaultStore_archivesUnreadableExistingStoreThenCreatesFreshStore() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let storeURL = directory.appending(path: "vault-primary.sqlite")
+        let walURL = sidecarURL(for: storeURL, suffix: "-wal")
+        let shmURL = sidecarURL(for: storeURL, suffix: "-shm")
+        let pendingKillphraseURL = directory.appending(path: "vault-primary.pending-killphrase-rehash.json")
+        let pendingSearchPassphraseURL = directory
+            .appending(path: "vault-primary.pending-search-passphrase-rehash.json")
+        try Data("not a sqlite store".utf8).write(to: storeURL)
+        try Data("wal".utf8).write(to: walURL)
+        try Data("shm".utf8).write(to: shmURL)
+        try Data("[]".utf8).write(to: pendingKillphraseURL)
+        try Data("[]".utf8).write(to: pendingSearchPassphraseURL)
+        let archiveURL = directory.appending(path: "failed-store")
+        let sut = PersistedLocalVaultStoreFactory(
+            storageDirectory: directory,
+            archiveDirectoryName: { "failed-store" },
+        )
+
+        let store = sut.makeVaultStore()
+
+        let result = try await store.retrieve(query: .init())
+        #expect(result == .empty())
+        #expect(FileManager.default
+            .fileExists(atPath: archiveURL.appending(path: storeURL.lastPathComponent).path(percentEncoded: false)))
+        #expect(FileManager.default
+            .fileExists(atPath: archiveURL.appending(path: walURL.lastPathComponent).path(percentEncoded: false)))
+        #expect(FileManager.default
+            .fileExists(atPath: archiveURL.appending(path: shmURL.lastPathComponent).path(percentEncoded: false)))
+        #expect(
+            FileManager.default.fileExists(
+                atPath: archiveURL.appending(path: pendingKillphraseURL.lastPathComponent).path(percentEncoded: false),
+            ),
+        )
+        #expect(
+            FileManager.default.fileExists(
+                atPath: archiveURL.appending(path: pendingSearchPassphraseURL.lastPathComponent)
+                    .path(percentEncoded: false),
+            ),
+        )
+        #expect(FileManager.default.fileExists(atPath: pendingKillphraseURL.path(percentEncoded: false)) == false)
+        #expect(FileManager.default.fileExists(atPath: pendingSearchPassphraseURL.path(percentEncoded: false)) == false)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func sidecarURL(for storeURL: URL, suffix: String) -> URL {
+        URL(fileURLWithPath: storeURL.path(percentEncoded: false) + suffix)
+    }
+}


### PR DESCRIPTION
## Summary

- Recover from unreadable SwiftData persisted vault stores by archiving active store files and opening a fresh store.
- Archive primary SQLite, WAL/SHM sidecars, and pending killphrase/search-passphrase rehash files.
- Add internal opener, filesystem, and failure-handler seams so recovery branches and fatal-wrapper messages can be tested deterministically.
- Harden `PersistedLocalVaultStoreFactoryTests` with parameterized coverage for active file combinations, archive name collisions, disappearing files, live move failures, retry failures, and real FileManager recovery behavior.

## Root Cause

A user with a prior development build could have a persisted store that SwiftData could no longer open in the TestFlight build. The old path fataled immediately instead of preserving the unreadable files and retrying with a fresh store.

## Impact

Users with an unreadable local store should launch successfully after the old store bundle is moved aside. Existing unreadable bytes are preserved in an archive directory rather than deleted.

## Validation

- `make format`
- `make lint`
- `xcodebuild build -scheme VaultiOS -destination platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5`
- `xcodebuild test -scheme VaultFeedTests -destination platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5 -only-testing:VaultFeedTests/PersistedLocalVaultStoreFactoryTests`
- `xcodebuild test -scheme VaultFeedTests -destination platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5`