### PR TITLE
Audit & expand VaultFeed test coverage

### DIFF
--- a/Vault/Sources/VaultFeed/Authentication/DeviceAuthenticationService.swift
+++ b/Vault/Sources/VaultFeed/Authentication/DeviceAuthenticationService.swift
@@ -33,9 +33,9 @@ public final class DeviceAuthenticationService {
     }
 
     /// Throws if the user is not authenticated or for any other error.
-    public func validateAuthentication(reason _: String) async throws {
+    public func validateAuthentication(reason: String) async throws {
         let result = try await policy
-            .authenticate(reason: "Validate access to the backup password store.")
+            .authenticate(reason: reason)
         guard result else {
             throw DeviceAuthenticationFailure.authenticationFailure
         }

--- a/Vault/Sources/VaultFeed/Storage/Migration/PendingKillphraseRehashStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/Migration/PendingKillphraseRehashStore.swift
@@ -26,10 +26,23 @@ struct PendingKillphraseRehashStore: @unchecked Sendable { // swiftlint:disable:
 
     private let fileURL: URL
     private let fileManager: FileManager
+    private let protectedWrite: (Data, URL) throws -> Void
+    private let overwriteWrite: (Data, URL) throws -> Void
 
-    init(fileURL: URL, fileManager: FileManager = .default) {
+    init(
+        fileURL: URL,
+        fileManager: FileManager = .default,
+        protectedWrite: @escaping (Data, URL) throws -> Void = { data, url in
+            try data.write(to: url, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+        },
+        overwriteWrite: @escaping (Data, URL) throws -> Void = { data, url in
+            try data.write(to: url, options: [.atomic])
+        },
+    ) {
         self.fileURL = fileURL
         self.fileManager = fileManager
+        self.protectedWrite = protectedWrite
+        self.overwriteWrite = overwriteWrite
     }
 
     /// Default location alongside the SwiftData store.
@@ -52,7 +65,7 @@ struct PendingKillphraseRehashStore: @unchecked Sendable { // swiftlint:disable:
     /// the device at least once after boot.
     func write(_ entries: [Entry]) throws {
         let data = try JSONEncoder().encode(entries)
-        try data.write(to: fileURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+        try protectedWrite(data, fileURL)
     }
 
     /// Overwrite the file with zeros, then delete. Best-effort residue
@@ -66,7 +79,7 @@ struct PendingKillphraseRehashStore: @unchecked Sendable { // swiftlint:disable:
             atPath: fileURL.path(percentEncoded: false),
         )[.size] as? Int, size > 0 {
             let zeros = Data(count: size)
-            try? zeros.write(to: fileURL, options: [.atomic])
+            try? overwriteWrite(zeros, fileURL)
         }
         try fileManager.removeItem(at: fileURL)
     }

--- a/Vault/Tests/FoundationExtensionsTests/LeakTrackingTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/LeakTrackingTests.swift
@@ -10,10 +10,10 @@ struct LeakTrackingTests {
     }
 
     @Test
-    func retainedInstance_recordsIssue() async throws {
+    func retainedInstance_recordsIssue() {
         let probe = Probe()
-        await withKnownIssue {
-            try await withLeakTracking {
+        withKnownIssue {
+            withLeakTracking {
                 _ = trackForMemoryLeaks(probe)
             }
         }
@@ -21,8 +21,8 @@ struct LeakTrackingTests {
     }
 
     @Test
-    func trackWithoutScope_recordsIssue() async {
-        await withKnownIssue {
+    func trackWithoutScope_recordsIssue() {
+        withKnownIssue {
             _ = trackForMemoryLeaks(Probe())
         }
     }

--- a/Vault/Tests/VaultFeedTests/Authentication/DeviceAuthenticationServiceTests.swift
+++ b/Vault/Tests/VaultFeedTests/Authentication/DeviceAuthenticationServiceTests.swift
@@ -191,6 +191,67 @@ struct DeviceAuthenticationServiceTests {
     }
 
     @Test
+    func policyExtension_authenticateReturnsFalseWhenNoPolicyAvailable() async throws {
+        let policy = DeviceAuthenticationPolicyCannotAuthenticate()
+
+        let result = try await policy.authenticate(reason: "reason")
+        let cannotAuthenticate: DeviceAuthenticationPolicyCannotAuthenticate = .cannotAuthenticate
+
+        #expect(policy.canAuthenticate == false)
+        #expect(result == false)
+        #expect(cannotAuthenticate.canAuthenticate == false)
+    }
+
+    @Test
+    func policyExtension_authenticateUsesPasscodeWhenBiometricsUnavailable() async throws {
+        let policy = DeviceAuthenticationPolicyMock(
+            canAuthenicateWithPasscode: true,
+            canAuthenticateWithBiometrics: false,
+        )
+        policy.authenticateWithPasscodeHandler = { reason in
+            #expect(reason == "reason")
+            return true
+        }
+
+        let result = try await policy.authenticate(reason: "reason")
+
+        #expect(result)
+        #expect(policy.authenticateWithBiometricsCallCount == 0)
+        #expect(policy.authenticateWithPasscodeCallCount == 1)
+    }
+
+    @Test
+    func staticPolicies_allowAndDenyAuthentication() async throws {
+        let allow = DeviceAuthenticationPolicyAlwaysAllow()
+        let deny = DeviceAuthenticationPolicyAlwaysDeny()
+
+        #expect(allow.canAuthenicateWithPasscode)
+        #expect(allow.canAuthenticateWithBiometrics)
+        #expect(try await allow.authenticateWithPasscode(reason: "reason"))
+        #expect(try await allow.authenticateWithBiometrics(reason: "reason"))
+
+        #expect(deny.canAuthenicateWithPasscode)
+        #expect(deny.canAuthenticateWithBiometrics)
+        #expect(try await deny.authenticateWithPasscode(reason: "reason") == false)
+        #expect(try await deny.authenticateWithBiometrics(reason: "reason") == false)
+
+        let factoryAllow: DeviceAuthenticationPolicyAlwaysAllow = .alwaysAllow
+        let factoryDeny: DeviceAuthenticationPolicyAlwaysDeny = .alwaysDeny
+
+        #expect(try await factoryAllow.authenticate(reason: "reason"))
+        #expect(try await factoryDeny.authenticate(reason: "reason") == false)
+    }
+
+    @Test
+    func devicePolicyDefaultFactoriesCreateUsingDevicePolicy() {
+        let defaultPolicy: DeviceAuthenticationPolicyUsingDevice = .default
+        let usingDevicePolicy: DeviceAuthenticationPolicyUsingDevice = .usingDevice
+
+        _ = defaultPolicy
+        _ = usingDevicePolicy
+    }
+
+    @Test
     func validateAuthenticationDoesNotThrowIfValid() async throws {
         let policy = DeviceAuthenticationPolicyMock(
             canAuthenicateWithPasscode: true,

--- a/Vault/Tests/VaultFeedTests/Authentication/DeviceAuthenticationServiceTests.swift
+++ b/Vault/Tests/VaultFeedTests/Authentication/DeviceAuthenticationServiceTests.swift
@@ -69,7 +69,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: false,
             canAuthenticateWithBiometrics: true,
         )
-        policy.authenticateWithBiometricsHandler = { _ in true }
+        policy.authenticateWithBiometricsHandler = { reason in
+            #expect(reason == "reason")
+            return true
+        }
         let sut = makeSUT(policy: policy)
 
         let result = try await sut.authenticate(reason: "reason")
@@ -84,7 +87,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: false,
             canAuthenticateWithBiometrics: true,
         )
-        policy.authenticateWithBiometricsHandler = { _ in false }
+        policy.authenticateWithBiometricsHandler = { reason in
+            #expect(reason == "reason")
+            return false
+        }
         let sut = makeSUT(policy: policy)
 
         let result = try await sut.authenticate(reason: "reason")
@@ -99,7 +105,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: false,
             canAuthenticateWithBiometrics: true,
         )
-        policy.authenticateWithBiometricsHandler = { _ in throw TestError() }
+        policy.authenticateWithBiometricsHandler = { reason in
+            #expect(reason == "reason")
+            throw TestError()
+        }
         let sut = makeSUT(policy: policy)
 
         await #expect(throws: (any Error).self) {
@@ -115,7 +124,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: true,
             canAuthenticateWithBiometrics: false,
         )
-        policy.authenticateWithPasscodeHandler = { _ in true }
+        policy.authenticateWithPasscodeHandler = { reason in
+            #expect(reason == "reason")
+            return true
+        }
         let sut = makeSUT(policy: policy)
 
         let result = try await sut.authenticate(reason: "reason")
@@ -130,7 +142,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: true,
             canAuthenticateWithBiometrics: false,
         )
-        policy.authenticateWithPasscodeHandler = { _ in false }
+        policy.authenticateWithPasscodeHandler = { reason in
+            #expect(reason == "reason")
+            return false
+        }
         let sut = makeSUT(policy: policy)
 
         let result = try await sut.authenticate(reason: "reason")
@@ -145,7 +160,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: true,
             canAuthenticateWithBiometrics: false,
         )
-        policy.authenticateWithPasscodeHandler = { _ in throw TestError() }
+        policy.authenticateWithPasscodeHandler = { reason in
+            #expect(reason == "reason")
+            throw TestError()
+        }
         let sut = makeSUT(policy: policy)
 
         await #expect(throws: (any Error).self) {
@@ -161,7 +179,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: true,
             canAuthenticateWithBiometrics: true,
         )
-        policy.authenticateWithBiometricsHandler = { _ in true }
+        policy.authenticateWithBiometricsHandler = { reason in
+            #expect(reason == "reason")
+            return true
+        }
         let sut = makeSUT(policy: policy)
 
         _ = try await sut.authenticate(reason: "reason")
@@ -175,7 +196,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: true,
             canAuthenticateWithBiometrics: true,
         )
-        policy.authenticateWithBiometricsHandler = { _ in true }
+        policy.authenticateWithBiometricsHandler = { reason in
+            #expect(reason == "reason")
+            return true
+        }
         let sut = makeSUT(policy: policy)
 
         await #expect(throws: Never.self) {
@@ -191,7 +215,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: true,
             canAuthenticateWithBiometrics: true,
         )
-        policy.authenticateWithBiometricsHandler = { _ in false }
+        policy.authenticateWithBiometricsHandler = { reason in
+            #expect(reason == "reason")
+            return false
+        }
         let sut = makeSUT(policy: policy)
 
         await #expect(throws: (any Error).self) {
@@ -205,7 +232,10 @@ struct DeviceAuthenticationServiceTests {
             canAuthenicateWithPasscode: true,
             canAuthenticateWithBiometrics: true,
         )
-        policy.authenticateWithBiometricsHandler = { _ in throw TestError() }
+        policy.authenticateWithBiometricsHandler = { reason in
+            #expect(reason == "reason")
+            throw TestError()
+        }
         let sut = makeSUT(policy: policy)
 
         await #expect(throws: (any Error).self) {

--- a/Vault/Tests/VaultFeedTests/CodeScanner/BackupImportScanningHandlerTests.swift
+++ b/Vault/Tests/VaultFeedTests/CodeScanner/BackupImportScanningHandlerTests.swift
@@ -29,6 +29,20 @@ struct BackupImportScanningHandlerTests {
         #expect(result == .continueScanning(.invalidCode))
     }
 
+    @Test
+    func makeSimulatedHandler_returnsExampleVault() throws {
+        let simulated = sut.makeSimulatedHandler()
+
+        let result = simulated.decodeSimulated()
+
+        guard case let .endScanning(.dataRetrieved(vault)) = result else {
+            Issue.record("Expected simulated vault")
+            return
+        }
+        #expect(vault.version == "1.0.0")
+        #expect(vault.data.isEmpty == false)
+    }
+
     @Test(arguments: ["", "invalid", "{}"])
     func decode_addShardErrorIgnoresError(string _: String) throws {
         let result1 = sut.decode(data: """

--- a/Vault/Tests/VaultFeedTests/Demo/VaultItemDemoFactoryTests.swift
+++ b/Vault/Tests/VaultFeedTests/Demo/VaultItemDemoFactoryTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+import VaultCore
+@testable import VaultFeed
+
+struct VaultItemDemoFactoryTests {
+    @Test
+    func makeTOTPCode_returnsDemoOTPItem() {
+        let sut = VaultItemDemoFactory()
+
+        let item = sut.makeTOTPCode()
+
+        assertCommonDemoMetadata(item, userDescription: "This is a demo TOTP code", showInQuickType: true)
+        guard case let .otpCode(code) = item.item else {
+            Issue.record("Expected OTP code")
+            return
+        }
+        #expect(code.type == .totp(period: 30))
+        #expect(code.data.issuer == "mcky.dev")
+        #expect(code.data.accountName.hasPrefix("mcky.dev "))
+    }
+
+    @Test
+    func makeHOTPCode_returnsDemoOTPItem() {
+        let sut = VaultItemDemoFactory()
+
+        let item = sut.makeHOTPCode()
+
+        assertCommonDemoMetadata(item, userDescription: "This is a demo HOTP code", showInQuickType: true)
+        guard case let .otpCode(code) = item.item else {
+            Issue.record("Expected OTP code")
+            return
+        }
+        #expect(code.data.issuer == "mcky.dev")
+        #expect(code.data.accountName.hasPrefix("example.com "))
+    }
+
+    @Test
+    func makeSecureNote_returnsDemoNoteItem() {
+        let sut = VaultItemDemoFactory()
+
+        let item = sut.makeSecureNote()
+
+        assertCommonDemoMetadata(item, userDescription: "This is a demo note", showInQuickType: false)
+        guard case let .secureNote(note) = item.item else {
+            Issue.record("Expected secure note")
+            return
+        }
+        #expect(note.title == "Hi there")
+        #expect(note.contents.hasPrefix("This is a test "))
+        #expect(note.format == .plain)
+    }
+
+    @Test
+    func makeEncryptedSecureNote_returnsEncryptedDemoNoteItem() throws {
+        let sut = VaultItemDemoFactory()
+
+        let item = try sut.makeEncryptedSecureNote()
+
+        assertCommonDemoMetadata(item, userDescription: "Hi there", showInQuickType: false)
+        guard case let .encryptedItem(encrypted) = item.item else {
+            Issue.record("Expected encrypted item")
+            return
+        }
+        #expect(encrypted.title == "Hi there")
+        #expect(encrypted.data.isEmpty == false)
+        #expect(encrypted.authentication.isEmpty == false)
+        #expect(encrypted.encryptionIV.isEmpty == false)
+    }
+}
+
+private func assertCommonDemoMetadata(
+    _ item: VaultItem.Write,
+    userDescription: String,
+    showInQuickType: Bool,
+    sourceLocation: SourceLocation = #_sourceLocation,
+) {
+    #expect(item.relativeOrder == 0, sourceLocation: sourceLocation)
+    #expect(item.userDescription == userDescription, sourceLocation: sourceLocation)
+    #expect(item.color == nil, sourceLocation: sourceLocation)
+    #expect(item.tags == [], sourceLocation: sourceLocation)
+    #expect(item.visibility == .always, sourceLocation: sourceLocation)
+    #expect(item.searchableLevel == .full, sourceLocation: sourceLocation)
+    #expect(item.searchPassphraseUpdate == .clear, sourceLocation: sourceLocation)
+    #expect(item.killphraseUpdate == .clear, sourceLocation: sourceLocation)
+    #expect(item.lockState == .notLocked, sourceLocation: sourceLocation)
+    #expect(item.showInQuickType == showInQuickType, sourceLocation: sourceLocation)
+    #expect(item.previewMode == .titleAndFirstLine, sourceLocation: sourceLocation)
+}

--- a/Vault/Tests/VaultFeedTests/Models/PresentationValueCoverageTests.swift
+++ b/Vault/Tests/VaultFeedTests/Models/PresentationValueCoverageTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import Testing
+import VaultCore
+@testable import VaultFeed
+
+struct PresentationValueCoverageTests {
+    @Test
+    func vaultItemVisibility_exposesIconsAndLocalizedText() {
+        for value in VaultItemVisibility.allCases {
+            #expect(value.systemIconName.isEmpty == false)
+            #expect(value.localizedTitle.isEmpty == false)
+            #expect(value.localizedSubtitle.isEmpty == false)
+        }
+    }
+
+    @Test
+    func vaultItemSearchableLevel_exposesIconsAndLocalizedText() {
+        for value in VaultItemSearchableLevel.allCases {
+            #expect(value.systemIconName.isEmpty == false)
+            #expect(value.localizedTitle.isEmpty == false)
+            #expect(value.localizedSubtitle.isEmpty == false)
+        }
+    }
+
+    @Test
+    func vaultItemLockState_exposesLockToggleAndLocalizedText() {
+        var unlocked = VaultItemLockState.notLocked
+        var locked = VaultItemLockState.lockedWithNativeSecurity
+
+        #expect(unlocked.isLocked == false)
+        #expect(locked.isLocked)
+
+        unlocked.isLocked = true
+        locked.isLocked = false
+
+        #expect(unlocked == .lockedWithNativeSecurity)
+        #expect(locked == .notLocked)
+
+        for value in VaultItemLockState.allCases {
+            #expect(value.systemIconName.isEmpty == false)
+            #expect(value.localizedTitle.isEmpty == false)
+            #expect(value.localizedSubtitle.isEmpty == false)
+        }
+    }
+
+    @Test
+    func vaultItemViewConfiguration_mapsVisibilityAndSearchableLevel() {
+        let cases: [(VaultItemVisibility, VaultItemSearchableLevel, VaultItemViewConfiguration)] = [
+            (.always, .none, .alwaysVisible),
+            (.onlySearch, .none, .alwaysVisible),
+            (.onlySearch, .full, .alwaysVisible),
+            (.onlySearch, .onlyTitle, .alwaysVisible),
+            (.onlySearch, .onlyPassphrase, .requiresSearchPassphrase),
+        ]
+
+        for (visibility, searchableLevel, expected) in cases {
+            #expect(VaultItemViewConfiguration(visibility: visibility, searchableLevel: searchableLevel) == expected)
+        }
+    }
+
+    @Test
+    func vaultItemViewConfiguration_exposesDerivedValuesAndLocalizedText() {
+        var configuration = VaultItemViewConfiguration.alwaysVisible
+        #expect(configuration.visibility == .always)
+        #expect(configuration.searchableLevel == .full)
+        #expect(configuration.isEnabled == false)
+
+        configuration.isEnabled = true
+        #expect(configuration == .requiresSearchPassphrase)
+        #expect(configuration.visibility == .onlySearch)
+        #expect(configuration.searchableLevel == .onlyPassphrase)
+
+        for value in VaultItemViewConfiguration.allCases {
+            #expect(value.systemIconName.isEmpty == false)
+            #expect(value.localizedTitle.isEmpty == false)
+            #expect(value.localizedSubtitle.isEmpty == false)
+        }
+    }
+
+    @Test
+    func notePreviewMode_exposesLocalizedTitles() {
+        for value in NotePreviewMode.allCases {
+            #expect(value.localizedTitle.isEmpty == false)
+        }
+    }
+
+    @Test
+    func otpCodeState_exposesGenerationAndVisibilityFlags() {
+        let error = PresentationError(userTitle: "title", userDescription: "description", debugDescription: "debug")
+        let cases: [(OTPCodeState, Bool, Bool)] = [
+            (.notReady, false, false),
+            (.finished, false, false),
+            (.obfuscated(.privacy), true, false),
+            (.obfuscated(.expiry), true, false),
+            (.visible("123456"), true, true),
+            (.locked(code: "123456"), true, false),
+            (.error(error, digits: 6), false, false),
+        ]
+
+        for (state, allowsNextCode, isVisible) in cases {
+            #expect(state.allowsNextCodeToBeGenerated == allowsNextCode)
+            #expect(state.isVisible == isVisible)
+        }
+    }
+
+    @Test
+    func loadingAndValidationStates_exposeConvenienceFlags() {
+        #expect(LoadingState.loading.isLoading)
+        #expect(LoadingState.loading.isNotLoading == false)
+        #expect(LoadingState.notLoading.isLoading == false)
+        #expect(LoadingState.notLoading.isNotLoading)
+
+        #expect(FieldValidationState.valid.isValid)
+        #expect(FieldValidationState.valid.isError == false)
+        #expect(FieldValidationState.invalid.isValid == false)
+        #expect(FieldValidationState.invalid.message == nil)
+        #expect(FieldValidationState.error(message: "Bad").isError)
+        #expect(FieldValidationState.error(message: "Bad").message == "Bad")
+    }
+
+    @Test
+    func textFormatAndSimplePresentationModels_exposeValues() {
+        #expect(TextFormat.markdown.localizedString == "Markdown")
+        #expect(TextFormat.plain.localizedString == "Plain")
+
+        let entry = DetailEntry(title: "Title", detail: "Detail", systemIconName: "info")
+        let item = DetailMenuItem(id: "id", title: "Menu", systemIconName: "list.bullet", entries: [entry])
+
+        #expect(item.id == "id")
+        #expect(item.entries.first?.detail == "Detail")
+    }
+
+    @Test
+    func vaultBackupEventKind_localizesAndCodableRoundTrips() throws {
+        let cases: [VaultBackupEvent.Kind] = [
+            .exportedToPDF,
+            .importedToPDF,
+            .exportedToDevice,
+            .importedFromDevice,
+            .exportedToAutoBackup(providerID: "provider"),
+        ]
+
+        for value in cases {
+            let data = try JSONEncoder().encode(value)
+            let decoded = try JSONDecoder().decode(VaultBackupEvent.Kind.self, from: data)
+
+            #expect(value.localizedTitle.isEmpty == false)
+            #expect(decoded == value)
+        }
+    }
+
+    @Test
+    func vaultItemColor_exposesDefaultsAndBrightening() {
+        #expect(VaultItemColor.default == .gray)
+        #expect(VaultItemColor.tagDefault.red == 0)
+        #expect(VaultItemColor.black == .init(red: 0, green: 0, blue: 0))
+        #expect(VaultItemColor.white == .init(red: 1, green: 1, blue: 1))
+
+        let brightened = VaultItemColor(red: 0.2, green: 0.3, blue: 0.4).brighten(amount: 0.5)
+
+        #expect(brightened.red > 0.2)
+        #expect(brightened.green > 0.4)
+        #expect(brightened.blue > 0.3)
+    }
+
+    @Test
+    func backupImportContext_exposesReadyText() {
+        let contexts: [BackupImportContext] = [.toEmptyVault, .merge, .override]
+
+        for context in contexts {
+            #expect(context.readyToImportTitle.isEmpty == false)
+            #expect(context.readyToImportDescription.isEmpty == false)
+        }
+    }
+
+    @Test
+    func backupPDFSizesExposeTitlesAndAspectRatios() {
+        for size in BackupCreatePDFViewModel.Size.allCases {
+            #expect(size.localizedTitle.isEmpty == false)
+            #expect(size.aspectRatio > 0)
+        }
+    }
+
+    @Test
+    func autoBackupRetentionExposeTitlesAndCleanupBehavior() {
+        let expectedCleanup: [AutoBackupRetention: Bool] = [
+            .days7: true,
+            .days30: true,
+            .year1: true,
+            .forever: false,
+        ]
+
+        for retention in AutoBackupRetention.allCases {
+            #expect(retention.localizedTitle.isEmpty == false)
+            #expect(retention.shouldCleanup == expectedCleanup[retention])
+        }
+    }
+
+    @Test
+    func encryptedItemPreviewVisibleTitleDependsOnPreviewModeAndTitle() {
+        let color = VaultItemColor(red: 0.1, green: 0.2, blue: 0.3)
+
+        #expect(EncryptedItemPreviewViewModel(title: "Secret", color: color, previewMode: .titleOnly)
+            .visibleTitle == "Secret")
+        #expect(EncryptedItemPreviewViewModel(title: "   ", color: color, previewMode: .titleAndFirstLine)
+            .visibleTitle == "Untitled Item")
+        #expect(EncryptedItemPreviewViewModel(title: "Secret", color: color, previewMode: .hidden).visibleTitle
+            .isEmpty == false)
+    }
+}

--- a/Vault/Tests/VaultFeedTests/Presentation/DetailEditStateTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/DetailEditStateTests.swift
@@ -213,6 +213,14 @@ struct DetailEditStateTests {
     }
 
     @Test
+    func operationErrorsExposeDescriptions() {
+        #expect(DetailEditState<MockState>.OperationError.save.description.isEmpty == false)
+        #expect(DetailEditState<MockState>.OperationError.delete.description.isEmpty == false)
+        #expect(DetailEditState<MockState>.OperationError.save.errorDescription?.isEmpty == false)
+        #expect(DetailEditState<MockState>.OperationError.delete.errorDescription?.isEmpty == false)
+    }
+
+    @Test
     func exitCurrentModeClearingDirtyState_clearsDirtyStateInEditMode() async {
         let sut = makeSUT()
         sut.startEditing()

--- a/Vault/Tests/VaultFeedTests/Presentation/DeviceTransferExportViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/DeviceTransferExportViewModelTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import TestHelpers
 import Testing
+import UIKit
 import VaultCore
 import VaultKeygen
 @testable import VaultFeed
@@ -132,6 +133,7 @@ struct DeviceTransferExportViewModelTests {
 
         // Advance the timer
         try await timer.finishTimer(at: 0)
+        await waitForDisplayingIndex(1, in: sut)
 
         // Should advance to index 1
         if case let .displayingQR(currentIndex, _) = sut.state {
@@ -162,6 +164,7 @@ struct DeviceTransferExportViewModelTests {
         // Each finishTimer call needs the correct index since a new timer is created each time
         for i in 0 ..< totalCount {
             try await timer.finishTimer(at: i)
+            await waitForDisplayingIndex((i + 1) % totalCount, in: sut)
         }
 
         // Should wrap back to index 0
@@ -183,16 +186,17 @@ struct DeviceTransferExportViewModelTests {
 
         await sut.generateShards()
 
-        let initialImage = sut.currentQRCodeImage
+        let initialImageData = sut.currentQRCodeImage?.pngData()
 
         // Advance the timer
         try await timer.finishTimer(at: 0)
+        await waitForDisplayingIndex(1, in: sut)
 
-        let updatedImage = sut.currentQRCodeImage
+        let updatedImageData = sut.currentQRCodeImage?.pngData()
 
-        // Images should be different (different QR code rendered)
-        #expect(initialImage != nil)
-        #expect(updatedImage != nil)
+        #expect(initialImageData != nil)
+        #expect(updatedImageData != nil)
+        #expect(initialImageData != updatedImageData)
     }
 }
 
@@ -229,5 +233,15 @@ extension DeviceTransferExportViewModelTests {
             backupEventLogger: backupEventLogger,
             intervalTimer: intervalTimer,
         )
+    }
+
+    private func waitForDisplayingIndex(_ expectedIndex: Int, in sut: DeviceTransferExportViewModel) async {
+        for _ in 0 ..< 100 {
+            if case let .displayingQR(currentIndex, _) = sut.state, currentIndex == expectedIndex {
+                return
+            }
+            await Task.yield()
+        }
+        Issue.record("Expected displayingQR index \(expectedIndex), got \(sut.state)")
     }
 }

--- a/Vault/Tests/VaultFeedTests/Presentation/LightweightViewModelCoverageTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/LightweightViewModelCoverageTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import VaultFeed
+
+@MainActor
+struct LightweightViewModelCoverageTests {
+    @Test
+    func backupCreateViewModel_exposesStrings() {
+        let sut = BackupCreateViewModel()
+
+        #expect(sut.strings.homeTitle.isEmpty == false)
+        #expect(sut.strings.backupPasswordSectionTitle.isEmpty == false)
+        #expect(sut.strings.backupPasswordCreateTitle.isEmpty == false)
+        #expect(sut.strings.backupPasswordUpdateTitle.isEmpty == false)
+        #expect(sut.strings.backupPasswordExportTitle.isEmpty == false)
+        #expect(sut.strings.backupPasswordLoadingTitle.isEmpty == false)
+        #expect(sut.strings.backupPasswordErrorTitle.isEmpty == false)
+        #expect(sut.strings.backupPasswordErrorDetail.isEmpty == false)
+    }
+
+    @Test
+    func backupRestoreViewModel_exposesStrings() {
+        let sut = BackupRestoreViewModel()
+
+        #expect(sut.strings.homeTitle.isEmpty == false)
+        #expect(sut.strings.backupPasswordImportTitle.isEmpty == false)
+    }
+
+    @Test
+    func vaultTagFeedViewModel_exposesStrings() {
+        let sut = VaultTagFeedViewModel()
+
+        #expect(sut.strings.title.isEmpty == false)
+        #expect(sut.strings.createTagTitle.isEmpty == false)
+        #expect(sut.strings.noTagsTitle.isEmpty == false)
+        #expect(sut.strings.noTagsDescription.isEmpty == false)
+        #expect(sut.strings.retrieveErrorTitle.isEmpty == false)
+        #expect(sut.strings.retrieveErrorDescription.isEmpty == false)
+    }
+
+    @Test
+    func settingsDangerViewModel_failedAuthenticationResetsDeletingState() async {
+        let deleter = VaultStoreDeleterMock()
+        let dataModel = anyVaultDataModel(vaultDeleter: deleter)
+        let authentication = DeviceAuthenticationService(policy: DeviceAuthenticationPolicyAlwaysDeny())
+        let sut = SettingsDangerViewModel(dataModel: dataModel, authenticationService: authentication)
+
+        await #expect(throws: (any Error).self) {
+            try await sut.deleteEntireVault()
+        }
+
+        #expect(sut.isDeleting == false)
+        #expect(deleter.deleteVaultCallCount == 0)
+    }
+
+    @Test
+    func genericVaultItemCopyActionHandler_returnsFirstChildAction() {
+        let itemID = Identifier<VaultItem>.new()
+        let first = VaultItemCopyActionHandlerMock()
+        let second = VaultItemCopyActionHandlerMock()
+        let expected = VaultTextCopyAction(text: "123456", requiresAuthenticationToCopy: false, contentType: .otp)
+        first.textToCopyForVaultItemHandler = { _ in nil }
+        second.textToCopyForVaultItemHandler = { id in
+            #expect(id == itemID)
+            return expected
+        }
+        let sut = GenericVaultItemCopyActionHandler(childHandlers: [first, second])
+
+        let action = sut.textToCopyForVaultItem(id: itemID)
+
+        #expect(action == expected)
+        #expect(first.textToCopyForVaultItemCallCount == 1)
+        #expect(second.textToCopyForVaultItemCallCount == 1)
+    }
+
+    @Test
+    func genericVaultItemCopyActionHandler_returnsNilWhenNoChildMatches() {
+        let child = VaultItemCopyActionHandlerMock()
+        let sut = GenericVaultItemCopyActionHandler(childHandlers: [child])
+
+        let action = sut.textToCopyForVaultItem(id: .new())
+
+        #expect(action == nil)
+        #expect(child.textToCopyForVaultItemCallCount == 1)
+    }
+}

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailEditsTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailEditsTests.swift
@@ -235,6 +235,47 @@ struct OTPCodeDetailEditsTests {
             try sut.asOTPAuthCode()
         }
     }
+
+    @Test
+    func isValid_validWhenExistingSearchPassphraseRequiresBlankPassphrase() {
+        var sut = OTPCodeDetailEdits.new()
+        sut.secretBase32String = "AA"
+        sut.issuerTitle = "issuer"
+        sut.viewConfig = .requiresSearchPassphrase
+        sut.hasExistingSearchPassphrase = true
+        sut.searchPassphrase = ""
+
+        #expect(sut.isValid)
+    }
+
+    @Test
+    func killphrasePropertiesReflectEnabledState() {
+        var sut = OTPCodeDetailEdits.new()
+
+        #expect(sut.killphraseIsEnabled == false)
+        #expect(sut.killphraseEnabledText == "None")
+        #expect(sut.killphraseEnabledIcon == "bolt")
+
+        sut.killphraseEnabled = true
+
+        #expect(sut.killphraseIsEnabled)
+        #expect(sut.killphraseEnabledText == "Enabled")
+        #expect(sut.killphraseEnabledIcon == "bolt.badge.checkmark.fill")
+    }
+
+    @Test
+    func isKillphraseValid_rejectsWhitespaceOnlyValue() {
+        var sut = OTPCodeDetailEdits.new()
+
+        sut.newKillphrase = ""
+        #expect(sut.isKillphraseValid)
+
+        sut.newKillphrase = "phrase"
+        #expect(sut.isKillphraseValid)
+
+        sut.newKillphrase = "   "
+        #expect(sut.isKillphraseValid == false)
+    }
 }
 
 // MARK: - Helpers

--- a/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailEditsTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailEditsTests.swift
@@ -106,4 +106,57 @@ struct SecureNoteDetailEditsTests {
 
         #expect(sut.contentPreviewLine == "")
     }
+
+    @Test
+    func isValid_validWhenExistingSearchPassphraseRequiresBlankPassphrase() {
+        var sut = SecureNoteDetailEdits.new()
+        sut.contents = "Nice"
+        sut.viewConfig = .requiresSearchPassphrase
+        sut.hasExistingSearchPassphrase = true
+        sut.searchPassphrase = ""
+
+        #expect(sut.isValid)
+    }
+
+    @Test
+    func killphrasePropertiesReflectEnabledState() {
+        var sut = SecureNoteDetailEdits.new()
+
+        #expect(sut.killphraseIsEnabled == false)
+        #expect(sut.killphraseEnabledText == "None")
+        #expect(sut.killphraseEnabledIcon == "bolt")
+
+        sut.killphraseEnabled = true
+
+        #expect(sut.killphraseIsEnabled)
+        #expect(sut.killphraseEnabledText == "Enabled")
+        #expect(sut.killphraseEnabledIcon == "bolt.badge.checkmark.fill")
+    }
+
+    @Test
+    func encryptionTextReflectsEncryptionState() {
+        var sut = SecureNoteDetailEdits.new()
+
+        #expect(sut.encrypted == false)
+        #expect(sut.encryptionEnabledText == "None")
+
+        sut.newEncryptionPassword = "password"
+
+        #expect(sut.encrypted)
+        #expect(sut.encryptionEnabledText == "Enabled")
+    }
+
+    @Test
+    func isKillphraseValid_rejectsWhitespaceOnlyValue() {
+        var sut = SecureNoteDetailEdits.new()
+
+        sut.newKillphrase = ""
+        #expect(sut.isKillphraseValid)
+
+        sut.newKillphrase = "phrase"
+        #expect(sut.isKillphraseValid)
+
+        sut.newKillphrase = "   "
+        #expect(sut.isKillphraseValid == false)
+    }
 }

--- a/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailViewModelTests.swift
@@ -365,6 +365,120 @@ struct SecureNoteDetailViewModelTests {
 
         #expect(sut.tagsThatAreSelected == [tag1, tag3])
     }
+
+    @Test
+    func allTags_returnsDataModelTags() {
+        let tags = [anyVaultItemTag(), anyVaultItemTag()]
+        let dataModel = anyVaultDataModel()
+        dataModel.allTags = tags
+
+        let sut = makeSUT(dataModel: dataModel)
+
+        #expect(sut.allTags == tags)
+    }
+
+    @Test
+    func delete_callsDeleteWrapper() async throws {
+        let editor = SecureNoteDetailEditorMock()
+        let sut = makeSUTEditing(editor: editor)
+
+        await sut.delete()
+
+        #expect(editor.deleteNoteCallCount == 1)
+    }
+
+    @Test
+    func dateValues_areNilWhenCreating() {
+        let sut = makeSUTCreating()
+
+        #expect(sut.createdDateValue == nil)
+        #expect(sut.updatedDateValue == nil)
+    }
+
+    @Test
+    func dateValues_includeCreatedAndSignificantUpdateWhenEditing() {
+        let created = Date(timeIntervalSince1970: 100)
+        let updated = created.addingTimeInterval(10)
+        let metadata = VaultItem.Metadata(
+            id: .new(),
+            created: created,
+            updated: updated,
+            relativeOrder: 0,
+            userDescription: "",
+            tags: [],
+            visibility: .always,
+            searchableLevel: .full,
+            searchPassphrase: nil,
+            killphrase: nil,
+            lockState: .notLocked,
+            color: nil,
+            showInQuickType: true,
+            previewMode: .titleAndFirstLine,
+        )
+        let sut = makeSUTEditing(storedMetadata: metadata)
+
+        #expect(sut.createdDateValue != nil)
+        #expect(sut.updatedDateValue != nil)
+    }
+
+    @Test
+    func dateValues_omitSmallUpdatedDateDelta() {
+        let created = Date(timeIntervalSince1970: 100)
+        let metadata = VaultItem.Metadata(
+            id: .new(),
+            created: created,
+            updated: created.addingTimeInterval(5),
+            relativeOrder: 0,
+            userDescription: "",
+            tags: [],
+            visibility: .always,
+            searchableLevel: .full,
+            searchPassphrase: nil,
+            killphrase: nil,
+            lockState: .notLocked,
+            color: nil,
+            showInQuickType: true,
+            previewMode: .titleAndFirstLine,
+        )
+        let sut = makeSUTEditing(storedMetadata: metadata)
+
+        #expect(sut.updatedDateValue == nil)
+    }
+
+    @Test
+    func detailEntries_includeDatesWhenAvailableAndVisibility() {
+        let created = Date(timeIntervalSince1970: 100)
+        let metadata = VaultItem.Metadata(
+            id: .new(),
+            created: created,
+            updated: created.addingTimeInterval(10),
+            relativeOrder: 0,
+            userDescription: "",
+            tags: [],
+            visibility: .onlySearch,
+            searchableLevel: .onlyPassphrase,
+            searchPassphrase: nil,
+            killphrase: nil,
+            lockState: .notLocked,
+            color: nil,
+            showInQuickType: true,
+            previewMode: .titleAndFirstLine,
+        )
+        let sut = makeSUTEditing(storedMetadata: metadata)
+
+        let entries = sut.detailEntries
+
+        #expect(entries.count == 3)
+        #expect(entries.map(\.systemIconName) == ["clock", "clock.arrow.2.circlepath", "eye.slash"])
+    }
+
+    @Test
+    func strings_areExposed() {
+        let sut = makeSUTCreating()
+
+        #expect(sut.strings.title.isEmpty == false)
+        #expect(sut.strings.tagCount(tags: 2).isEmpty == false)
+    }
 }
 
 extension SecureNoteDetailViewModelTests {

--- a/Vault/Tests/VaultFeedTests/Presentation/VaultDataModelEditorAdapterTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/VaultDataModelEditorAdapterTests.swift
@@ -80,6 +80,7 @@ struct VaultDataModelEditorAdapterTests {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: tagStore)
+        await loadDigesters(on: dataModel)
         let sut = makeSUT(dataModel: dataModel)
 
         var code = uniqueCode()
@@ -114,6 +115,13 @@ struct VaultDataModelEditorAdapterTests {
             store.updateHandler = { _, data in
                 defer { confirmation() }
                 #expect(data.userDescription == "new description")
+                #expect(data.visibility == .always)
+                #expect(data.searchableLevel == .full)
+                #expect(data.searchPassphraseUpdate == .clear)
+                assertKillphrase(data.killphraseUpdate, matches: "new kill", using: dataModel)
+                #expect(data.lockState == .notLocked)
+                #expect(data.showInQuickType == true)
+                #expect(data.previewMode == .titleAndFirstLine)
                 switch data.item {
                 case let .otpCode(otpCode):
                     #expect(otpCode.data.accountName == "new account name")
@@ -180,6 +188,7 @@ struct VaultDataModelEditorAdapterTests {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: tagStore)
+        await loadDigesters(on: dataModel)
         let sut = makeSUT(dataModel: dataModel)
 
         var initialEdits = SecureNoteDetailEdits.new()
@@ -196,7 +205,10 @@ struct VaultDataModelEditorAdapterTests {
                 #expect(data.userDescription == "second line")
                 #expect(data.visibility == .onlySearch)
                 #expect(data.searchableLevel == .onlyPassphrase)
-                // Search passphrase is now stored as one-way digest, so we can't assert plaintext equality here.
+                assertSearchPassphrase(data.searchPassphraseUpdate, matches: "pass", using: dataModel)
+                assertKillphrase(data.killphraseUpdate, matches: "this is kill", using: dataModel)
+                #expect(data.lockState == .lockedWithNativeSecurity)
+                #expect(data.previewMode == .titleAndFirstLine)
                 switch data.item {
                 case let .secureNote(note):
                     #expect(note.title == "first line")
@@ -216,6 +228,7 @@ struct VaultDataModelEditorAdapterTests {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: tagStore)
+        await loadDigesters(on: dataModel)
         let deriverMock = KeyDeriverMock<Bits256>()
         let keyDeriverFactory = VaultKeyDeriverFactoryMock()
         keyDeriverFactory.makeVaultItemKeyDeriverHandler = {
@@ -239,7 +252,10 @@ struct VaultDataModelEditorAdapterTests {
                     #expect(data.userDescription == "", "Empty because note is encrypted")
                     #expect(data.visibility == .onlySearch)
                     #expect(data.searchableLevel == .onlyPassphrase)
-                    // Search passphrase is now stored as one-way digest, so we can't assert plaintext equality here.
+                    assertSearchPassphrase(data.searchPassphraseUpdate, matches: "pass", using: dataModel)
+                    assertKillphrase(data.killphraseUpdate, matches: "this is kill", using: dataModel)
+                    #expect(data.lockState == .lockedWithNativeSecurity)
+                    #expect(data.previewMode == .titleAndFirstLine)
                     switch data.item {
                     case let .encryptedItem(item):
                         #expect(item.title == "first line")
@@ -270,6 +286,7 @@ struct VaultDataModelEditorAdapterTests {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: tagStore)
+        await loadDigesters(on: dataModel)
         let keyDeriverFactory = VaultKeyDeriverFactoryMock()
         keyDeriverFactory.makeVaultItemKeyDeriverHandler = { .testing }
         let sut = makeSUT(dataModel: dataModel, keyDeriverFactory: keyDeriverFactory)
@@ -290,7 +307,10 @@ struct VaultDataModelEditorAdapterTests {
                 #expect(data.userDescription == "", "Empty because note is encrypted")
                 #expect(data.visibility == .onlySearch)
                 #expect(data.searchableLevel == .onlyPassphrase)
-                // Search passphrase is now stored as one-way digest, so we can't assert plaintext equality here.
+                assertSearchPassphrase(data.searchPassphraseUpdate, matches: "pass", using: dataModel)
+                assertKillphrase(data.killphraseUpdate, matches: "this is kill", using: dataModel)
+                #expect(data.lockState == .lockedWithNativeSecurity)
+                #expect(data.previewMode == .titleAndFirstLine)
                 switch data.item {
                 case let .encryptedItem(item):
                     #expect(item.title == "first line")
@@ -326,6 +346,7 @@ struct VaultDataModelEditorAdapterTests {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: tagStore)
+        await loadDigesters(on: dataModel)
         let sut = makeSUT(dataModel: dataModel)
 
         var note = anySecureNote()
@@ -349,7 +370,10 @@ struct VaultDataModelEditorAdapterTests {
                 #expect(data.userDescription == "second line")
                 #expect(data.visibility == .always)
                 #expect(data.searchableLevel == .full)
-                // Search passphrase is now stored as one-way digest, so we can't assert plaintext equality here.
+                #expect(data.searchPassphraseUpdate == .clear)
+                assertKillphrase(data.killphraseUpdate, matches: "this kill", using: dataModel)
+                #expect(data.lockState == .notLocked)
+                #expect(data.previewMode == .titleAndFirstLine)
                 switch data.item {
                 case let .secureNote(note):
                     #expect(note.title == "first line")
@@ -450,5 +474,42 @@ extension VaultDataModelEditorAdapterTests {
             color: nil,
             showInQuickType: true,
         )
+    }
+
+    private func loadDigesters(on dataModel: VaultDataModel) async {
+        await dataModel.loadKillphraseDigester()
+        await dataModel.loadSearchPassphraseDigester()
+    }
+
+    private func assertSearchPassphrase(
+        _ update: VaultItem.SearchPassphraseUpdate,
+        matches phrase: String,
+        using dataModel: VaultDataModel,
+    ) {
+        guard case let .set(digest) = update else {
+            Issue.record("Expected search passphrase to be set, got \(update)")
+            return
+        }
+        #expect(dataModel.searchPassphraseDigester?.matches(
+            query: phrase,
+            salt: digest.salt,
+            digest: digest.digest,
+        ) == true)
+    }
+
+    private func assertKillphrase(
+        _ update: VaultItem.KillphraseUpdate,
+        matches phrase: String,
+        using dataModel: VaultDataModel,
+    ) {
+        guard case let .set(digest) = update else {
+            Issue.record("Expected killphrase to be set, got \(update)")
+            return
+        }
+        #expect(dataModel.killphraseDigester?.matches(
+            query: phrase,
+            salt: digest.salt,
+            digest: digest.digest,
+        ) == true)
     }
 }

--- a/Vault/Tests/VaultFeedTests/Presentation/VaultTagDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/VaultTagDetailViewModelTests.swift
@@ -32,6 +32,9 @@ struct VaultTagDetailViewModelTests {
         #expect(sut.currentTag.name == "")
         #expect(sut.currentTag.color == .tagDefault)
         #expect(sut.currentTag.iconName == "tag.fill")
+        #expect(sut.isNew)
+        #expect(sut.isExistingItem == false)
+        #expect(sut.isDirty == false)
     }
 
     @Test
@@ -43,6 +46,38 @@ struct VaultTagDetailViewModelTests {
         #expect(sut.currentTag.name == "tag")
         #expect(sut.currentTag.color == color)
         #expect(sut.currentTag.iconName == "figure.2.arms.open")
+        #expect(sut.isNew == false)
+        #expect(sut.isExistingItem)
+        #expect(sut.isDirty == false)
+    }
+
+    @Test
+    func staticIconOptions_includeDefaultAndExposeInstanceOptions() {
+        let sut = makeSUT()
+
+        #expect(VaultTagDetailViewModel.defaultIconOption == VaultItemTag.defaultIconName)
+        #expect(VaultTagDetailViewModel.systemIconOptions.first == VaultItemTag.defaultIconName)
+        #expect(sut.systemIconOptions == VaultTagDetailViewModel.systemIconOptions)
+    }
+
+    @Test
+    func isDirty_tracksCurrentTagChanges() {
+        let sut = makeSUT()
+
+        sut.currentTag.name = "new tag"
+
+        #expect(sut.isDirty)
+    }
+
+    @Test
+    func isValidToSave_requiresNonBlankName() {
+        let sut = makeSUT()
+
+        sut.currentTag.name = "   "
+        #expect(sut.isValidToSave == false)
+
+        sut.currentTag.name = "work"
+        #expect(sut.isValidToSave)
     }
 
     @Test

--- a/Vault/Tests/VaultFeedTests/Storage/AutoBackupProviderCoverageTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/AutoBackupProviderCoverageTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import VaultFeed
+
+struct AutoBackupProviderCoverageTests {
+    @Test
+    func iCloudDriveProvider_unconfiguredStateIsAvailableForSetup() async throws {
+        let sut = iCloudDriveProvider()
+
+        #expect(sut.id == iCloudDriveProvider.providerID)
+        #expect(sut.displayName == "Files")
+        #expect(sut.iconSystemName == "folder")
+        #expect(await sut.folderDisplayName == nil)
+        #expect(await sut.isConfigured == false)
+        #expect(await sut.configurationSummary == nil)
+        #expect(await sut.isAvailable)
+        #expect(await sut.configurationData != nil)
+    }
+
+    @Test
+    func iCloudDriveProvider_restoresAndClearsConfiguration() async throws {
+        let sut = iCloudDriveProvider()
+        let config = iCloudDriveProviderConfiguration(
+            folderBookmark: Data([0, 1, 2]),
+            folderDisplayName: "Backups",
+        )
+        let data = try JSONEncoder().encode(config)
+
+        try await sut.restoreConfiguration(from: data)
+
+        #expect(await sut.isConfigured)
+        #expect(await sut.folderDisplayName == "Backups")
+        #expect(await sut.configurationSummary == "Backups")
+        #expect(await sut.isAvailable == false)
+
+        await sut.clearConfiguration()
+
+        #expect(await sut.isConfigured == false)
+        #expect(await sut.folderDisplayName == nil)
+    }
+
+    @Test
+    func iCloudDriveProvider_restoreRejectsInvalidData() async {
+        let sut = iCloudDriveProvider()
+
+        await #expect(throws: (any Error).self) {
+            try await sut.restoreConfiguration(from: Data("invalid".utf8))
+        }
+    }
+
+    @Test
+    func iCloudDriveProvider_unconfiguredOperationsThrowProviderNotConfigured() async {
+        let sut = iCloudDriveProvider()
+
+        await expectProviderNotConfigured {
+            try await sut.write(data: Data("payload".utf8), filename: "backup.pdf")
+        }
+        await expectProviderNotConfigured {
+            _ = try await sut.listBackups()
+        }
+        await expectProviderNotConfigured {
+            try await sut.delete(filename: "backup.pdf")
+        }
+    }
+
+    @Test
+    func autoBackupErrorsExposeDescriptionsAndRecoverySuggestions() {
+        let cases: [AutoBackupError] = [
+            .noProviderSelected,
+            .providerNotConfigured,
+            .providerUnavailable(reason: "Unavailable"),
+            .accessDenied,
+            .backupPasswordNotSet,
+            .pdfGenerationFailed(reason: "PDF"),
+            .writeFailed(reason: "Write"),
+            .cleanupFailed(reason: "Cleanup"),
+            .networkUnavailable,
+            .storageFull,
+            .unknown(reason: "Unknown"),
+        ]
+
+        for error in cases {
+            #expect(error.errorDescription?.isEmpty == false)
+            #expect(error.recoverySuggestion?.isEmpty == false)
+        }
+    }
+}
+
+private func expectProviderNotConfigured(
+    _ operation: () async throws -> Void,
+    sourceLocation: SourceLocation = #_sourceLocation,
+) async {
+    do {
+        try await operation()
+        Issue.record("Expected providerNotConfigured", sourceLocation: sourceLocation)
+    } catch let error as AutoBackupError {
+        #expect(error == .providerNotConfigured, sourceLocation: sourceLocation)
+    } catch {
+        Issue.record("Expected AutoBackupError, got \(error)", sourceLocation: sourceLocation)
+    }
+}

--- a/Vault/Tests/VaultFeedTests/Storage/AutoBackupServiceImplTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/AutoBackupServiceImplTests.swift
@@ -226,6 +226,55 @@ struct AutoBackupServiceImplTests {
         #expect(sut.status == .error(.backupPasswordNotSet))
     }
 
+    @Test @LeakTracked
+    func forceBackup_writesPDFUpdatesConfigurationAndLogsEvent() async throws {
+        let clock = EpochClockMock(currentTime: 100)
+        let provider = BackupStorageProviderStub(id: "test")
+        let store = VaultStoreStub()
+        var exportDescriptions: [String] = []
+        store.exportVaultHandler = { userDescription in
+            exportDescriptions.append(userDescription)
+            return .init(userDescription: userDescription, items: [uniqueVaultItem()], tags: [])
+        }
+        let dataModel = anyVaultDataModel(vaultStore: store)
+        try await dataModel.store(backupPassword: anyBackupPassword())
+        await dataModel.setup()
+        let expectedHash = try #require(dataModel.currentPayloadHash)
+        let logger = BackupEventLoggerMock()
+        let sut = try makeSUT(
+            clock: clock,
+            providers: [provider],
+            dataModel: dataModel,
+            backupEventLogger: logger,
+        )
+        await Task.yield()
+        await sut.setRetention(.forever)
+        await sut.selectProvider(id: "test")
+
+        await confirmation("Auto-backup event logged", expectedCount: 1) { confirmLog in
+            logger.exportedToAutoBackupHandler = { date, hash, providerID in
+                #expect(date == clock.currentDate)
+                #expect(hash == expectedHash)
+                #expect(providerID == "test")
+                confirmLog()
+            }
+
+            await sut.forceBackup()
+        }
+
+        let written = try #require(provider.writtenData.first)
+        let timestamp = VaultDateFormatter(timezone: .current).formatForFileName(date: clock.currentDate)
+        #expect(provider.writeCallCount == 1)
+        #expect(written.filename == "vault-auto-backup-\(timestamp).pdf")
+        #expect(written.data.isNotEmpty)
+        #expect(sut.configuration.lastBackupHash == expectedHash.value.base64EncodedString())
+        #expect(sut.configuration.lastBackupDate == clock.currentDate)
+        #expect(sut.status == .completed(clock.currentDate))
+        #expect(logger.exportedToAutoBackupCallCount == 1)
+        #expect(provider.listBackupsCallCount == 0)
+        #expect(exportDescriptions == ["", "Auto-backup"])
+    }
+
     // MARK: - Cleanup Old Backups
 
     @Test @LeakTracked
@@ -378,10 +427,12 @@ extension AutoBackupServiceImplTests {
         clock: EpochClockMock = EpochClockMock(currentTime: 100),
         defaults: UserDefaults? = nil,
         providers: [BackupStorageProviderStub] = [],
+        dataModel: VaultDataModel? = nil,
+        backupEventLogger: BackupEventLoggerMock? = nil,
     ) throws -> AutoBackupServiceImpl {
         let userDefaults = try defaults ?? testUserDefaults()
-        let dataModel = trackForMemoryLeaks(anyVaultDataModel())
-        let backupEventLogger = trackForMemoryLeaks(BackupEventLoggerMock())
+        let dataModel = trackForMemoryLeaks(dataModel ?? anyVaultDataModel())
+        let backupEventLogger = trackForMemoryLeaks(backupEventLogger ?? BackupEventLoggerMock())
         trackForMemoryLeaks(clock)
         for provider in providers {
             trackForMemoryLeaks(provider)

--- a/Vault/Tests/VaultFeedTests/Storage/BackupEventLoggerImplTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/BackupEventLoggerImplTests.swift
@@ -43,6 +43,38 @@ struct BackupEventLoggerImplTests {
     }
 
     @Test
+    func exportedToDevice_savesDeviceEvent() throws {
+        let defaults = try testUserDefaults()
+        let clock = EpochClockMock(currentTime: 100)
+        let sut = makeSUT(defaults: defaults, clock: clock)
+        let date = Date(timeIntervalSince1970: 1234)
+
+        sut.exportedToDevice(date: date, hash: .init(value: Data(hex: "1234")))
+
+        let backup = sut.lastBackupEvent()
+        #expect(backup?.backupDate == clock.currentDate)
+        #expect(backup?.eventDate == date)
+        #expect(backup?.payloadHash == .init(value: Data(hex: "1234")))
+        #expect(backup?.kind == .exportedToDevice)
+    }
+
+    @Test
+    func exportedToAutoBackup_savesAutoBackupEvent() throws {
+        let defaults = try testUserDefaults()
+        let clock = EpochClockMock(currentTime: 100)
+        let sut = makeSUT(defaults: defaults, clock: clock)
+        let date = Date(timeIntervalSince1970: 1234)
+
+        sut.exportedToAutoBackup(date: date, hash: .init(value: Data(hex: "1234")), providerID: "icloud-drive")
+
+        let backup = sut.lastBackupEvent()
+        #expect(backup?.backupDate == clock.currentDate)
+        #expect(backup?.eventDate == date)
+        #expect(backup?.payloadHash == .init(value: Data(hex: "1234")))
+        #expect(backup?.kind == .exportedToAutoBackup(providerID: "icloud-drive"))
+    }
+
+    @Test
     func exportedToPDF_savesToDefaults() throws {
         let defaults = try testUserDefaults()
         let beforeKeys = defaults.keys

--- a/Vault/Tests/VaultFeedTests/Storage/EncryptedVaultDecoderTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/EncryptedVaultDecoderTests.swift
@@ -70,6 +70,20 @@ struct EncryptedVaultDecoderTests {
             _ = try sut.decryptAndDecode(key: .random(), encryptedVault: encryptedBackup)
         }
     }
+
+    @Test
+    func decoderErrorsExposeLocalizedText() {
+        let errors: [EncryptedVaultDecoderError] = [
+            .incompatibleVersion,
+            .decryption,
+            .decoding,
+        ]
+
+        for error in errors {
+            #expect(error.errorDescription?.isEmpty == false)
+            #expect(error.failureReason?.isEmpty == false)
+        }
+    }
 }
 
 // MARK: - Helpers

--- a/Vault/Tests/VaultFeedTests/Storage/PendingKillphraseRehashStoreTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PendingKillphraseRehashStoreTests.swift
@@ -66,19 +66,26 @@ struct PendingKillphraseRehashStoreTests {
 
     @Test
     func clear_overwritesContentBeforeDeletion() throws {
-        // Best-effort residue minimisation: clear() writes zeros over
-        // the file before removing it. We can't easily prove residue is
-        // gone (filesystem semantics), but we can verify the overwrite
-        // path runs by intercepting between overwrite and delete.
         let url = tmpURL()
         defer { try? FileManager.default.removeItem(at: url) }
-        let sut = makeSUT(at: url)
+        var overwrittenData: Data?
+        var overwrittenURL: URL?
+        let sut = PendingKillphraseRehashStore(
+            fileURL: url,
+            overwriteWrite: { data, url in
+                overwrittenData = data
+                overwrittenURL = url
+                try data.write(to: url, options: [.atomic])
+            },
+        )
         try sut.write([.init(itemID: UUID(), phrase: "secret")])
         let originalSize = try sizeOfFile(at: url)
         #expect(originalSize > 0)
 
         try sut.clear()
 
+        #expect(overwrittenURL == url)
+        #expect(overwrittenData == Data(count: originalSize))
         #expect(FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) == false)
     }
 }

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
@@ -1669,8 +1669,9 @@ final class PersistedLocalVaultStoreTests {
 
     @Test
     func deleteItemsMatchingKillphrase_hasNoEffectIfVaultEmpty() async throws {
-        await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
+        let didDelete = await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
 
+        #expect(didDelete == false)
         try await assertStoreContains(exactlyItems: [])
     }
 
@@ -1687,8 +1688,9 @@ final class PersistedLocalVaultStoreTests {
         )
         try await sut.importAndOverrideVault(payload: payload)
 
-        await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
+        let didDelete = await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
 
+        #expect(didDelete == true)
         try await assertStoreContains(exactlyItems: [item2, item3])
     }
 
@@ -1705,8 +1707,9 @@ final class PersistedLocalVaultStoreTests {
         )
         try await sut.importAndOverrideVault(payload: payload)
 
-        await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
+        let didDelete = await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
 
+        #expect(didDelete == true)
         try await assertStoreContains(exactlyItems: [item3])
     }
 
@@ -1723,8 +1726,9 @@ final class PersistedLocalVaultStoreTests {
         )
         try await sut.importAndOverrideVault(payload: payload)
 
-        await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
+        let didDelete = await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
 
+        #expect(didDelete == true)
         try await assertStoreContains(exactlyItems: [item2, item3])
     }
 
@@ -1741,8 +1745,9 @@ final class PersistedLocalVaultStoreTests {
         )
         try await sut.importAndOverrideVault(payload: payload)
 
-        await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
+        let didDelete = await sut.deleteItems(matchingKillphrase: "a", using: testDigester)
 
+        #expect(didDelete == true)
         try await assertStoreContains(exactlyItems: [item1, item3])
     }
 
@@ -1760,11 +1765,15 @@ final class PersistedLocalVaultStoreTests {
 
         try await sut.importAndOverrideVault(payload: payload)
 
-        await sut.deleteItems(matchingKillphrase: "", using: testDigester)
-        await sut.deleteItems(matchingKillphrase: " ", using: testDigester)
-        await sut.deleteItems(matchingKillphrase: "       ", using: testDigester)
-        await sut.deleteItems(matchingKillphrase: "\n", using: testDigester)
+        let emptyDidDelete = await sut.deleteItems(matchingKillphrase: "", using: testDigester)
+        let spaceDidDelete = await sut.deleteItems(matchingKillphrase: " ", using: testDigester)
+        let spacesDidDelete = await sut.deleteItems(matchingKillphrase: "       ", using: testDigester)
+        let newlineDidDelete = await sut.deleteItems(matchingKillphrase: "\n", using: testDigester)
 
+        #expect(emptyDidDelete == false)
+        #expect(spaceDidDelete == false)
+        #expect(spacesDidDelete == false)
+        #expect(newlineDidDelete == false)
         try await assertStoreContains(exactlyItems: [item1, item2, item3])
     }
 }

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedSchemaMigrationPlanTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedSchemaMigrationPlanTests.swift
@@ -41,6 +41,218 @@ struct PersistedSchemaMigrationPlanTests {
         #expect(ObjectIdentifier(schemas[2]) == ObjectIdentifier(PersistedSchemaV3.self))
     }
 
+    @Test
+    func v1Models_includeAllLegacyModelTypes() {
+        let models = PersistedSchemaV1.models
+
+        #expect(models.count == 4)
+        #expect(ObjectIdentifier(models[0]) == ObjectIdentifier(PersistedSchemaV1.PersistedVaultItem.self))
+        #expect(ObjectIdentifier(models[1]) == ObjectIdentifier(PersistedSchemaV1.PersistedOTPDetails.self))
+        #expect(ObjectIdentifier(models[2]) == ObjectIdentifier(PersistedSchemaV1.PersistedNoteDetails.self))
+        #expect(ObjectIdentifier(models[3]) == ObjectIdentifier(PersistedSchemaV1.PersistedVaultTag.self))
+    }
+
+    @Test
+    func v2Models_includeAllLegacyModelTypes() {
+        let models = PersistedSchemaV2.models
+
+        #expect(models.count == 4)
+        #expect(ObjectIdentifier(models[0]) == ObjectIdentifier(PersistedSchemaV2.PersistedVaultItem.self))
+        #expect(ObjectIdentifier(models[1]) == ObjectIdentifier(PersistedSchemaV2.PersistedOTPDetails.self))
+        #expect(ObjectIdentifier(models[2]) == ObjectIdentifier(PersistedSchemaV2.PersistedNoteDetails.self))
+        #expect(ObjectIdentifier(models[3]) == ObjectIdentifier(PersistedSchemaV2.PersistedVaultTag.self))
+    }
+
+    @Test
+    func v1PersistedModels_storeAssignedValues() {
+        let id = UUID()
+        let tagID = UUID()
+        let created = Date(timeIntervalSince1970: 100)
+        let updated = Date(timeIntervalSince1970: 200)
+        let color = PersistedColor(red: 0.1, green: 0.2, blue: 0.3)
+        let tag = PersistedSchemaV1.PersistedVaultTag(
+            id: tagID,
+            title: "tag",
+            color: color,
+            iconName: "star",
+            items: [],
+        )
+        let noteDetails = PersistedSchemaV1.PersistedNoteDetails(
+            title: "note",
+            contents: "contents",
+            format: "markdown",
+        )
+        let otpDetails = PersistedSchemaV1.PersistedOTPDetails(
+            accountName: "account",
+            issuer: "issuer",
+            algorithm: "SHA1",
+            authType: "TOTP",
+            counter: 123,
+            digits: 6,
+            period: 30,
+            secretData: Data([1, 2, 3]),
+            secretFormat: "BASE_32",
+        )
+        let encryptedDetails = PersistedSchemaV1.PersistedEncryptedItemDetails(
+            version: "1",
+            title: "encrypted",
+            data: Data([4]),
+            authentication: Data([5]),
+            encryptionIV: Data([6]),
+            keygenSalt: Data([7]),
+            keygenSignature: "TEST",
+        )
+
+        let item = PersistedSchemaV1.PersistedVaultItem(
+            id: id,
+            relativeOrder: 99,
+            createdDate: created,
+            updatedDate: updated,
+            userDescription: "description",
+            visibility: "ALWAYS",
+            searchableLevel: "FULL",
+            searchPassphrase: "search",
+            killphrase: "kill",
+            lockState: "LOCKED",
+            color: color,
+            showInQuickType: false,
+            previewMode: "HIDDEN",
+            tags: [tag],
+            noteDetails: noteDetails,
+            otpDetails: otpDetails,
+            encryptedItemDetails: encryptedDetails,
+        )
+
+        #expect(item.id == id)
+        #expect(item.relativeOrder == 99)
+        #expect(item.createdDate == created)
+        #expect(item.updatedDate == updated)
+        #expect(item.userDescription == "description")
+        #expect(item.visibility == "ALWAYS")
+        #expect(item.searchableLevel == "FULL")
+        #expect(item.searchPassphrase == "search")
+        #expect(item.killphrase == "kill")
+        #expect(item.lockState == "LOCKED")
+        #expect(item.color?.red == 0.1)
+        #expect(item.showInQuickType == false)
+        #expect(item.previewMode == "HIDDEN")
+        #expect(item.tags.map(\.id) == [tagID])
+        #expect(item.noteDetails?.title == "note")
+        #expect(item.noteDetails?.contents == "contents")
+        #expect(item.noteDetails?.format == "markdown")
+        #expect(item.otpDetails?.accountName == "account")
+        #expect(item.otpDetails?.issuer == "issuer")
+        #expect(item.otpDetails?.algorithm == "SHA1")
+        #expect(item.otpDetails?.authType == "TOTP")
+        #expect(item.otpDetails?.counter == 123)
+        #expect(item.otpDetails?.digits == 6)
+        #expect(item.otpDetails?.period == 30)
+        #expect(item.otpDetails?.secretData == Data([1, 2, 3]))
+        #expect(item.otpDetails?.secretFormat == "BASE_32")
+        #expect(item.encryptedItemDetails?.version == "1")
+        #expect(item.encryptedItemDetails?.title == "encrypted")
+        #expect(item.encryptedItemDetails?.data == Data([4]))
+        #expect(item.encryptedItemDetails?.authentication == Data([5]))
+        #expect(item.encryptedItemDetails?.encryptionIV == Data([6]))
+        #expect(item.encryptedItemDetails?.keygenSalt == Data([7]))
+        #expect(item.encryptedItemDetails?.keygenSignature == "TEST")
+
+        var hasher = Hasher()
+        tag.hash(into: &hasher)
+    }
+
+    @Test
+    func v2PersistedModels_storeAssignedValues() {
+        let id = UUID()
+        let tagID = UUID()
+        let created = Date(timeIntervalSince1970: 300)
+        let updated = Date(timeIntervalSince1970: 400)
+        let color = PersistedColor(red: 0.4, green: 0.5, blue: 0.6)
+        let tag = PersistedSchemaV2.PersistedVaultTag(
+            id: tagID,
+            title: "tag",
+            color: color,
+            iconName: "tag",
+            items: [],
+        )
+        let noteDetails = PersistedSchemaV2.PersistedNoteDetails(
+            title: "note",
+            contents: "contents",
+            format: "plain",
+        )
+        let otpDetails = PersistedSchemaV2.PersistedOTPDetails(
+            accountName: "account",
+            issuer: "issuer",
+            algorithm: "SHA256",
+            authType: "HOTP",
+            counter: 456,
+            digits: 8,
+            period: 60,
+            secretData: Data([8, 9]),
+            secretFormat: "BASE_32",
+        )
+        let encryptedDetails = PersistedSchemaV2.PersistedEncryptedItemDetails(
+            version: "2",
+            title: "encrypted",
+            data: Data([10]),
+            authentication: Data([11]),
+            encryptionIV: Data([12]),
+            keygenSalt: Data([13]),
+            keygenSignature: "TEST",
+        )
+
+        let item = PersistedSchemaV2.PersistedVaultItem(
+            id: id,
+            relativeOrder: 100,
+            createdDate: created,
+            updatedDate: updated,
+            userDescription: "description",
+            visibility: "ONLY_SEARCH",
+            searchableLevel: "ONLY_TITLE",
+            searchPassphrase: "search",
+            killphraseSalt: Data([14]),
+            killphraseDigest: Data([15]),
+            lockState: "LOCKED",
+            color: color,
+            showInQuickType: false,
+            previewMode: "TITLE_ONLY",
+            tags: [tag],
+            noteDetails: noteDetails,
+            otpDetails: otpDetails,
+            encryptedItemDetails: encryptedDetails,
+        )
+
+        #expect(item.id == id)
+        #expect(item.relativeOrder == 100)
+        #expect(item.createdDate == created)
+        #expect(item.updatedDate == updated)
+        #expect(item.userDescription == "description")
+        #expect(item.visibility == "ONLY_SEARCH")
+        #expect(item.searchableLevel == "ONLY_TITLE")
+        #expect(item.searchPassphrase == "search")
+        #expect(item.killphraseSalt == Data([14]))
+        #expect(item.killphraseDigest == Data([15]))
+        #expect(item.lockState == "LOCKED")
+        #expect(item.color?.green == 0.5)
+        #expect(item.showInQuickType == false)
+        #expect(item.previewMode == "TITLE_ONLY")
+        #expect(item.tags.map(\.id) == [tagID])
+        #expect(item.noteDetails?.format == "plain")
+        #expect(item.otpDetails?.accountName == "account")
+        #expect(item.otpDetails?.algorithm == "SHA256")
+        #expect(item.otpDetails?.authType == "HOTP")
+        #expect(item.otpDetails?.counter == 456)
+        #expect(item.otpDetails?.digits == 8)
+        #expect(item.otpDetails?.period == 60)
+        #expect(item.otpDetails?.secretData == Data([8, 9]))
+        #expect(item.encryptedItemDetails?.version == "2")
+        #expect(item.encryptedItemDetails?.title == "encrypted")
+        #expect(item.encryptedItemDetails?.keygenSignature == "TEST")
+
+        var hasher = Hasher()
+        tag.hash(into: &hasher)
+    }
+
     // NOTE: An end-to-end migration test that seeds an earlier store and
     // then opens it through the latest schema would be the ideal
     // coverage, but it is not feasible in this test target: every

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedSchemaMigrationPlanTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedSchemaMigrationPlanTests.swift
@@ -10,6 +10,23 @@ struct PersistedSchemaMigrationPlanTests {
         let stages = PersistedSchemaMigrationPlan.stages
 
         #expect(stages.count == 2)
+        guard case let .custom(fromVersion, toVersion, willMigrate, didMigrate) = stages[0] else {
+            Issue.record("Expected first stage to be custom")
+            return
+        }
+        #expect(ObjectIdentifier(fromVersion) == ObjectIdentifier(PersistedSchemaV1.self))
+        #expect(ObjectIdentifier(toVersion) == ObjectIdentifier(PersistedSchemaV2.self))
+        #expect(willMigrate != nil)
+        #expect(didMigrate == nil)
+
+        guard case let .custom(fromVersion, toVersion, willMigrate, didMigrate) = stages[1] else {
+            Issue.record("Expected second stage to be custom")
+            return
+        }
+        #expect(ObjectIdentifier(fromVersion) == ObjectIdentifier(PersistedSchemaV2.self))
+        #expect(ObjectIdentifier(toVersion) == ObjectIdentifier(PersistedSchemaV3.self))
+        #expect(willMigrate != nil)
+        #expect(didMigrate == nil)
     }
 
     @Test
@@ -19,6 +36,9 @@ struct PersistedSchemaMigrationPlanTests {
         // All versioned schemas must be registered so SwiftData knows
         // how to migrate forward through every step in the chain.
         #expect(schemas.count == 3)
+        #expect(ObjectIdentifier(schemas[0]) == ObjectIdentifier(PersistedSchemaV1.self))
+        #expect(ObjectIdentifier(schemas[1]) == ObjectIdentifier(PersistedSchemaV2.self))
+        #expect(ObjectIdentifier(schemas[2]) == ObjectIdentifier(PersistedSchemaV3.self))
     }
 
     // NOTE: An end-to-end migration test that seeds an earlier store and

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemDecoderTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemDecoderTests.swift
@@ -103,6 +103,30 @@ extension PersistedVaultItemDecoderTests {
         #expect(decoded.metadata.color == expectedColor)
     }
 
+    @Test
+    func decodeMetadata_decodesQuickTypeAndPreviewMode() throws {
+        let item = makePersistedItem(
+            showInQuickType: false,
+            previewMode: NotePreviewMode.hidden.rawValue,
+        )
+        let sut = makeSUT()
+
+        let decoded = try sut.decode(item: item)
+
+        #expect(decoded.metadata.showInQuickType == false)
+        #expect(decoded.metadata.previewMode == .hidden)
+    }
+
+    @Test
+    func decodeMetadata_invalidPreviewModeDefaultsToTitleAndFirstLine() throws {
+        let item = makePersistedItem(previewMode: "INVALID")
+        let sut = makeSUT()
+
+        let decoded = try sut.decode(item: item)
+
+        #expect(decoded.metadata.previewMode == .titleAndFirstLine)
+    }
+
     @Test(arguments: [
         (VaultItemVisibility.always, "ALWAYS"),
         (VaultItemVisibility.onlySearch, "ONLY_SEARCH"),
@@ -500,6 +524,8 @@ extension PersistedVaultItemDecoderTests {
         killphraseDigest: Data? = nil,
         lockState: String? = nil,
         color: PersistedColor? = nil,
+        showInQuickType: Bool = true,
+        previewMode: String = NotePreviewMode.titleAndFirstLine.rawValue,
         tags: [PersistedVaultTag] = [],
         noteDetails: PersistedNoteDetails? = nil,
         otpDetails: PersistedOTPDetails? = .init(
@@ -529,8 +555,8 @@ extension PersistedVaultItemDecoderTests {
             killphraseDigest: killphraseDigest,
             lockState: lockState,
             color: color,
-            showInQuickType: true,
-            previewMode: NotePreviewMode.titleAndFirstLine.rawValue,
+            showInQuickType: showInQuickType,
+            previewMode: previewMode,
             tags: tags,
             noteDetails: noteDetails,
             otpDetails: otpDetails,

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemEncoderTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemEncoderTests.swift
@@ -129,6 +129,21 @@ extension PersistedVaultItemEncoderTests {
         #expect(newCode.color?.blue == 0.7)
     }
 
+    @Test
+    func encodeMetadata_encodesQuickTypeAndPreviewMode() throws {
+        let sut = makeSUT()
+        let item = makeWritable(
+            code: uniqueCode(),
+            showInQuickType: false,
+            previewMode: .hidden,
+        )
+
+        let encoded = try encode(sut: sut, item: item)
+
+        #expect(encoded.showInQuickType == false)
+        #expect(encoded.previewMode == NotePreviewMode.hidden.rawValue)
+    }
+
     @Test(arguments: [
         (VaultItemVisibility.always, "ALWAYS"),
         (VaultItemVisibility.onlySearch, "ONLY_SEARCH"),

--- a/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
@@ -96,6 +96,27 @@ final class VaultDataModelTests {
     }
 
     @Test
+    func searchPresentationValues_reflectQueryAndFilters() {
+        let sut = makeSUT()
+        let originalHash = sut.itemSearchHash
+
+        sut.items = [uniqueVaultItem(), uniqueVaultItem()]
+        sut.itemsSearchQuery = "query"
+        sut.itemsFilteringByTags = [.new(), .new()]
+
+        #expect(sut.itemSearchHash != originalHash)
+        #expect(sut.feedTitle.isEmpty == false)
+        #expect(sut.filteringByTagsDescription.isEmpty == false)
+    }
+
+    @Test
+    func feedTitle_usesListTitleWhenNotSearching() {
+        let sut = makeSUT()
+
+        #expect(sut.feedTitle.isEmpty == false)
+    }
+
+    @Test
     func init_initialPayloadHashIsNil() {
         let store = VaultStoreStub()
         let sut = makeSUT(vaultStore: store)
@@ -112,6 +133,60 @@ final class VaultDataModelTests {
 
         #expect(store.calledMethods == [.export])
         #expect(sut.currentPayloadHash != nil)
+    }
+
+    @Test
+    func loadKillphraseDigester_isNoopWhenAlreadyLoaded() async throws {
+        let keyStore = KillphraseKeyStoreMock()
+        keyStore.loadOrCreateHandler = {
+            try KeyData<Bits256>(data: Data(repeating: 1, count: 32))
+        }
+        let sut = makeSUT(killphraseKeyStore: keyStore)
+
+        await sut.loadKillphraseDigester()
+        await sut.loadKillphraseDigester()
+
+        #expect(keyStore.loadOrCreateCallCount == 1)
+        #expect(sut.killphraseDigester != nil)
+    }
+
+    @Test
+    func loadKillphraseDigester_swallowsKeyStoreError() async {
+        let keyStore = KillphraseKeyStoreMock()
+        keyStore.loadOrCreateHandler = { throw TestError() }
+        let sut = makeSUT(killphraseKeyStore: keyStore)
+
+        await sut.loadKillphraseDigester()
+
+        #expect(keyStore.loadOrCreateCallCount == 1)
+        #expect(sut.killphraseDigester == nil)
+    }
+
+    @Test
+    func loadSearchPassphraseDigester_isNoopWhenAlreadyLoaded() async throws {
+        let keyStore = SearchPassphraseKeyStoreMock()
+        keyStore.loadOrCreateHandler = {
+            try KeyData<Bits256>(data: Data(repeating: 2, count: 32))
+        }
+        let sut = makeSUT(searchPassphraseKeyStore: keyStore)
+
+        await sut.loadSearchPassphraseDigester()
+        await sut.loadSearchPassphraseDigester()
+
+        #expect(keyStore.loadOrCreateCallCount == 1)
+        #expect(sut.searchPassphraseDigester != nil)
+    }
+
+    @Test
+    func loadSearchPassphraseDigester_swallowsKeyStoreError() async {
+        let keyStore = SearchPassphraseKeyStoreMock()
+        keyStore.loadOrCreateHandler = { throw TestError() }
+        let sut = makeSUT(searchPassphraseKeyStore: keyStore)
+
+        await sut.loadSearchPassphraseDigester()
+
+        #expect(keyStore.loadOrCreateCallCount == 1)
+        #expect(sut.searchPassphraseDigester == nil)
     }
 
     @Test
@@ -259,6 +334,16 @@ final class VaultDataModelTests {
 
             #expect(sut.hasAnyItems == hasItems)
         }
+    }
+
+    @Test
+    func reloadTags_presentsErrorOnFailure() async {
+        let tagStore = VaultTagStoreErroring(error: TestError())
+        let sut = makeSUT(vaultTagStore: tagStore)
+
+        await sut.reloadTags()
+
+        #expect(sut.allTagsRetrievalError != nil)
     }
 
     @Test
@@ -562,6 +647,7 @@ final class VaultDataModelTests {
         await sut.loadBackupPassword()
 
         #expect(sut.backupPassword.isRetryable == false)
+        #expect(sut.backupPassword.fetchedPassword == password)
     }
 
     @Test
@@ -616,6 +702,48 @@ final class VaultDataModelTests {
 
         #expect(vaultStore.calledMethods == [.retrieve])
         #expect(vaultTagStore.calledMethods == [.retrieveTags])
+    }
+
+    @Test
+    func code_returnsMatchingItemFromLoadedItems() {
+        let expected = uniqueVaultItem()
+        let sut = makeSUT()
+        sut.items = [uniqueVaultItem(), expected]
+
+        #expect(sut.code(id: expected.id) == expected)
+        #expect(sut.code(id: .new()) == nil)
+    }
+
+    @Test
+    func incrementCounter_incrementsStoreReloadsAndNotifiesChange() async throws {
+        let store = VaultStoreStub()
+        let sut = makeSUT(vaultStore: store)
+
+        try await confirmation { confirm in
+            sut.onDataChanged = {
+                confirm()
+            }
+
+            try await sut.incrementCounter(id: .new())
+        }
+
+        #expect(store.incrementCounterCallCount == 1)
+        #expect(store.calledMethods == [.retrieve])
+    }
+
+    @Test
+    func autofillStoreHelpers_forwardToStore() async throws {
+        let autofillStore = VaultOTPAutofillStoreMock()
+        let sut = makeSUT(vaultOtpAutofillStore: autofillStore)
+        let id = UUID()
+
+        let identities = try await sut.getOTPAutofillStoreIdentities()
+        try await sut.removeOTPItemFromAutofillStore(id: id)
+
+        #expect(identities == [])
+        #expect(autofillStore.getAllIdentitiesCallCount == 1)
+        #expect(autofillStore.removeCallCount == 1)
+        #expect(autofillStore.removeArgValues.first?.id == id)
     }
 
     @Test

--- a/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
@@ -299,6 +299,54 @@ final class VaultDataModelTests {
     }
 
     @Test
+    func reloadItems_syncsAutofillAndNotifiesWhenKillphraseDeletesItems() async throws {
+        let store = VaultStoreStub()
+        let killphraseDeleter = VaultStoreKillphraseDeleterMock()
+        let vaultOtpAutofillStore = VaultOTPAutofillStoreMock()
+        let keyStore = KillphraseKeyStoreMock()
+        keyStore.loadOrCreateHandler = {
+            (try? KeyData<Bits256>(data: Data(repeating: 0xAA, count: 32))) ?? .zero()
+        }
+        let sut = makeSUT(
+            vaultStore: store,
+            vaultKillphraseDeleter: killphraseDeleter,
+            vaultOtpAutofillStore: vaultOtpAutofillStore,
+            killphraseKeyStore: keyStore,
+        )
+        await sut.setup()
+        sut.itemsSearchQuery = "hello world"
+        let remainingItem = uniqueVaultItem()
+        var retrievedQueries: [String?] = []
+
+        killphraseDeleter.deleteItemsHandler = { query, _ in
+            #expect(query == "hello world")
+            return true
+        }
+        store.retrieveHandler = { query in
+            retrievedQueries.append(query.filterText)
+            return .init(items: [remainingItem])
+        }
+
+        await confirmation("Autofill synced", expectedCount: 1) { confirmSync in
+            vaultOtpAutofillStore.syncAllHandler = { items in
+                #expect(items.map(\.id) == [remainingItem.id])
+                confirmSync()
+            }
+
+            await confirmation("Data change notified", expectedCount: 1) { confirmChange in
+                sut.onDataChanged = {
+                    confirmChange()
+                }
+
+                await sut.reloadItems()
+            }
+        }
+
+        #expect(retrievedQueries == ["hello world", nil])
+        #expect(vaultOtpAutofillStore.syncAllCallCount == 1)
+    }
+
+    @Test
     func insert_createsItemInStoreAndReloads() async throws {
         let store = VaultStoreStub()
         let sut = makeSUT(vaultStore: store)


### PR DESCRIPTION
## Summary

- Forward caller-supplied authentication reason through `DeviceAuthenticationService.validateAuthentication` instead of using hard-coded backup-store reason.
- Inject protected and overwrite file-write closures into `PendingKillphraseRehashStore` so write protection and clear-time zeroing behavior can be tested directly.
- Expand VaultFeed audit coverage across authentication policies, backup import scanning, presentation values, lightweight view models, detail-edit state, OTP and secure-note edit models, tag/detail view models, device-transfer export, and editor adapter behavior.
- Add and strengthen storage coverage for auto-backup providers and service behavior, backup event logging, encrypted vault decoding, pending killphrase rehash persistence, persisted local vault stores, schema migration plans, vault item encoding/decoding, and `VaultDataModel` helpers.
- Update leak-tracking tests to match synchronous helper paths so `CI_iOS` suite builds cleanly.

## Why

This branch closes VaultFeed audit gaps by asserting more small but security-relevant behavior around authentication, pending killphrase rehash persistence, backup flows, presentation state, and persisted data transformations. Production changes are narrow testability updates that let tests verify existing behavior without relying on filesystem side effects or hard-coded authentication prompts.

## Impact

No user-facing feature changes expected. Authentication validation prompt now preserves reason passed by caller, and pending killphrase rehash file writes remain behaviorally equivalent while becoming injectable for focused tests.

## Validation

- CI_iOS tests pass