### PR TITLE
Fix OTP widget store retries

### DIFF
--- a/Vault/Package.swift
+++ b/Vault/Package.swift
@@ -299,7 +299,7 @@ let package = Package(
         ),
         .testTarget(
             name: "VaultiOSWidgetsTests",
-            dependencies: ["VaultiOSWidgets", "VaultiOSShared", "TestHelpers"],
+            dependencies: ["VaultiOSWidgets", "VaultiOSShared", "VaultCore", "VaultFeed", "TestHelpers"],
             exclude: ["__Snapshots__"],
             swiftSettings: swiftSettings,
             plugins: testTargetPlugins,

--- a/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStoreFactory.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedLocalVaultStoreFactory.swift
@@ -2,6 +2,11 @@ import Foundation
 import SwiftData
 
 public final class PersistedLocalVaultStoreFactory {
+    public enum RecoveryMode: Equatable, Sendable {
+        case recoverExistingStore
+        case openOnly
+    }
+
     private static let storeFilename = "vault-primary.sqlite"
     private static let storeSidecarSuffixes = ["-shm", "-wal"]
 
@@ -9,6 +14,7 @@ public final class PersistedLocalVaultStoreFactory {
     private let storeOpener: any PersistedLocalVaultStoreOpening
     private let fileSystem: any PersistedLocalVaultStoreRecoveryFileSystem
     private let archiveDirectoryName: () -> String
+    private let recoveryMode: RecoveryMode
     private let failureHandler: (String) -> PersistedLocalVaultStore
 
     public init(
@@ -20,11 +26,13 @@ public final class PersistedLocalVaultStoreFactory {
                 .replacingOccurrences(of: ":", with: "-")
             return "vault-primary.failed-open-\(timestamp)"
         },
+        recoveryMode: RecoveryMode = .recoverExistingStore,
     ) {
         self.storageDirectory = storageDirectory
         storeOpener = SwiftDataPersistedLocalVaultStoreOpener()
         fileSystem = FileManagerPersistedLocalVaultStoreRecoveryFileSystem(fileManager: fileManager)
         self.archiveDirectoryName = archiveDirectoryName
+        self.recoveryMode = recoveryMode
         failureHandler = { fatalError($0) }
     }
 
@@ -33,12 +41,14 @@ public final class PersistedLocalVaultStoreFactory {
         storeOpener: any PersistedLocalVaultStoreOpening,
         fileSystem: any PersistedLocalVaultStoreRecoveryFileSystem,
         archiveDirectoryName: @escaping () -> String,
+        recoveryMode: RecoveryMode = .recoverExistingStore,
         failureHandler: @escaping (String) -> PersistedLocalVaultStore = { fatalError($0) },
     ) {
         self.storageDirectory = storageDirectory
         self.storeOpener = storeOpener
         self.fileSystem = fileSystem
         self.archiveDirectoryName = archiveDirectoryName
+        self.recoveryMode = recoveryMode
         self.failureHandler = failureHandler
     }
 
@@ -56,11 +66,14 @@ public final class PersistedLocalVaultStoreFactory {
         }
     }
 
-    func makeVaultStoreOrThrow() throws -> PersistedLocalVaultStore {
+    public func makeVaultStoreOrThrow() throws -> PersistedLocalVaultStore {
         let storeURL = storageDirectory.appending(path: Self.storeFilename)
         do {
             return try storeOpener.open(storeURL: storeURL)
         } catch {
+            guard recoveryMode == .recoverExistingStore else {
+                throw StoreConnectionError.unableToConnect(error)
+            }
             try recoverExistingStoreIfPresent(storeURL: storeURL, connectionError: error)
             do {
                 return try storeOpener.open(storeURL: storeURL)

--- a/Vault/Sources/VaultiOS/VaultRoot.swift
+++ b/Vault/Sources/VaultiOS/VaultRoot.swift
@@ -234,6 +234,7 @@ public enum VaultRoot {
             autoBackupService.notifyDataChanged()
             reloadWidgetTimelines()
         }
+        reloadWidgetTimelines()
     }
 
     @MainActor

--- a/Vault/Sources/VaultiOSWidgets/Intent/OTPWidgetItemEntity.swift
+++ b/Vault/Sources/VaultiOSWidgets/Intent/OTPWidgetItemEntity.swift
@@ -52,14 +52,14 @@ public struct OTPWidgetItemEntityQuery: EntityQuery, Sendable {
 
     public func entities(for identifiers: [OTPWidgetItemEntity.ID]) async throws -> [OTPWidgetItemEntity] {
         let lookup = Set(identifiers)
-        let items = try await loader.eligibleItems()
+        guard let items = try? await loader.eligibleItems() else { return [] }
         return items
             .filter { lookup.contains($0.id.rawValue) }
             .compactMap(Self.makeEntity(from:))
     }
 
     public func suggestedEntities() async throws -> [OTPWidgetItemEntity] {
-        let items = try await loader.eligibleItems()
+        guard let items = try? await loader.eligibleItems() else { return [] }
         return items.compactMap(Self.makeEntity(from:))
     }
 

--- a/Vault/Sources/VaultiOSWidgets/Loader/WidgetVaultLoader.swift
+++ b/Vault/Sources/VaultiOSWidgets/Loader/WidgetVaultLoader.swift
@@ -10,28 +10,36 @@ public import VaultFeed
 /// `VaultRoot.vaultStore`), so this type opens its own `PersistedLocalVaultStore`
 /// pointed at the same App Group container.
 public actor WidgetVaultLoader {
+    public typealias StoreFactory = @Sendable () throws -> any VaultStoreReader
+
     /// Process-wide default instance. Widget timeline providers should reuse
     /// the same loader across calls so the underlying `ModelContainer` is
     /// built once.
     public static let shared = WidgetVaultLoader()
 
-    private let store: PersistedLocalVaultStore
+    private let makeStore: StoreFactory
+    private var store: (any VaultStoreReader)?
 
-    public init(store: PersistedLocalVaultStore? = nil) {
+    public init(store: (any VaultStoreReader)? = nil) {
         if let store {
             self.store = store
+            makeStore = { store }
         } else {
-            self.store = PersistedLocalVaultStoreFactory(
-                storageDirectory: VaultSharedStorage.directory(),
-            ).makeVaultStore()
+            self.store = nil
+            makeStore = Self.makeSharedStore
         }
+    }
+
+    public init(makeStore: @escaping StoreFactory) {
+        self.makeStore = makeStore
+        store = nil
     }
 
     /// All items that are currently eligible to appear in a widget. Hidden,
     /// locked, killphrase-protected, and search-passphrase items are filtered
     /// out — see `VaultItemWidgetEligibility`.
     public func eligibleItems() async throws -> [VaultItem] {
-        let result = try await store.retrieve(query: .init())
+        let result = try await retrieveItems()
         return result.items.filter(VaultItemWidgetEligibility.isEligible)
     }
 
@@ -39,10 +47,33 @@ public actor WidgetVaultLoader {
     /// not exist or has become ineligible since the user configured the widget.
     /// The two states are indistinguishable to callers by design (manifesto C2).
     public func eligibleItem(id: UUID) async throws -> VaultItem? {
-        let result = try await store.retrieve(query: .init())
+        let result = try await retrieveItems()
         guard let item = result.items.first(where: { $0.id.rawValue == id }) else {
             return nil
         }
         return VaultItemWidgetEligibility.isEligible(item) ? item : nil
+    }
+
+    private static func makeSharedStore() throws -> any VaultStoreReader {
+        try PersistedLocalVaultStoreFactory(
+            storageDirectory: VaultSharedStorage.directory(),
+            recoveryMode: .openOnly,
+        ).makeVaultStoreOrThrow()
+    }
+
+    private func retrieveItems() async throws -> VaultRetrievalResult<VaultItem> {
+        let currentStore = try store ?? openStore()
+        do {
+            return try await currentStore.retrieve(query: .init())
+        } catch {
+            store = nil
+            throw error
+        }
+    }
+
+    private func openStore() throws -> any VaultStoreReader {
+        let openedStore = try makeStore()
+        store = openedStore
+        return openedStore
     }
 }

--- a/Vault/Sources/VaultiOSWidgets/OTPWidgetProvider.swift
+++ b/Vault/Sources/VaultiOSWidgets/OTPWidgetProvider.swift
@@ -45,6 +45,10 @@ public struct OTPWidgetProvider: AppIntentTimelineProvider {
         for configuration: OTPWidgetIntent,
         in _: Context,
     ) async -> Timeline<OTPWidgetEntry> {
+        await makeTimeline(for: configuration)
+    }
+
+    func makeTimeline(for configuration: OTPWidgetIntent) async -> Timeline<OTPWidgetEntry> {
         guard let entityID = configuration.item?.id else {
             return unavailableTimeline()
         }

--- a/Vault/TestPlans/CI/iOSAllTests.xctestplan
+++ b/Vault/TestPlans/CI/iOSAllTests.xctestplan
@@ -77,6 +77,13 @@
     {
       "target" : {
         "containerPath" : "container:",
+        "identifier" : "VaultiOSWidgetsTests",
+        "name" : "VaultiOSWidgetsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:",
         "identifier" : "VaultFeedTests",
         "name" : "VaultFeedTests"
       }

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
@@ -180,6 +180,33 @@ struct PersistedLocalVaultStoreFactoryTests {
     }
 
     @Test(arguments: ActiveFileScenario.all)
+    func makeVaultStoreOrThrow_openOnlyModeFailsWithoutRecoveryWhenInitialOpenFails(
+        _ scenario: ActiveFileScenario,
+    ) {
+        let directory = makeDirectoryURL()
+        let activeURLs = Set(scenario.files.map { url(for: $0, in: directory) })
+        let opener = ScriptedStoreOpener(results: [.failure(FactoryTestError.initialOpen)])
+        let fileSystem = FakeRecoveryFileSystem(existingFiles: activeURLs)
+        let sut = makeSUT(
+            directory: directory,
+            opener: opener,
+            fileSystem: fileSystem,
+            recoveryMode: .openOnly,
+        )
+
+        expectStoreConnectionError(.unableToConnect) {
+            _ = try sut.makeVaultStoreOrThrow()
+        }
+
+        #expect(opener.openedStoreURLs == [url(for: .primary, in: directory)])
+        #expect(fileSystem.createdDirectories == [])
+        #expect(fileSystem.movedItems.isEmpty)
+        for activeURL in activeURLs {
+            #expect(fileSystem.fileExists(at: activeURL))
+        }
+    }
+
+    @Test(arguments: ActiveFileScenario.all)
     func makeVaultStoreOrThrow_archivesActiveFileCombinations(_ scenario: ActiveFileScenario) throws {
         let directory = makeDirectoryURL()
         let archiveURL = directory.appending(path: "failed-store")
@@ -543,6 +570,7 @@ private func makeSUT(
     opener: ScriptedStoreOpener,
     fileSystem: FakeRecoveryFileSystem,
     archiveDirectoryName: @escaping () -> String = { "failed-store" },
+    recoveryMode: PersistedLocalVaultStoreFactory.RecoveryMode = .recoverExistingStore,
     failureHandler: @escaping (String) -> PersistedLocalVaultStore = { fatalError($0) },
 ) -> PersistedLocalVaultStoreFactory {
     PersistedLocalVaultStoreFactory(
@@ -550,6 +578,7 @@ private func makeSUT(
         storeOpener: opener,
         fileSystem: fileSystem,
         archiveDirectoryName: archiveDirectoryName,
+        recoveryMode: recoveryMode,
         failureHandler: failureHandler,
     )
 }

--- a/Vault/Tests/VaultiOSWidgetsTests/OTPWidgetLoadingTests.swift
+++ b/Vault/Tests/VaultiOSWidgetsTests/OTPWidgetLoadingTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Testing
+import VaultCore
+import VaultFeed
+@testable import VaultiOSWidgets
+
+@Suite
+struct OTPWidgetLoadingTests {
+    @Test
+    func eligibleItems_retriesAfterStoreOpenFailure() async throws {
+        let item = makeOTPVaultItem(accountName: "first", issuer: "Issuer")
+        let store = FakeVaultStoreReader(results: [.success(.init(items: [item]))])
+        let factory = StoreFactoryScript(results: [
+            .failure(.open),
+            .success(store),
+        ])
+        let loader = WidgetVaultLoader(makeStore: { try factory.makeStore() })
+
+        await #expect(throws: WidgetTestError.open) {
+            try await loader.eligibleItems()
+        }
+        let items = try await loader.eligibleItems()
+
+        #expect(items == [item])
+        #expect(factory.openCallCount == 2)
+        #expect(await store.retrieveCallCount == 1)
+    }
+
+    @Test
+    func eligibleItems_clearsCachedStoreAfterRetrieveFailure() async throws {
+        let item = makeOTPVaultItem(accountName: "second", issuer: "Issuer")
+        let failingStore = FakeVaultStoreReader(results: [.failure(.retrieve)])
+        let succeedingStore = FakeVaultStoreReader(results: [.success(.init(items: [item]))])
+        let factory = StoreFactoryScript(results: [
+            .success(failingStore),
+            .success(succeedingStore),
+        ])
+        let loader = WidgetVaultLoader(makeStore: { try factory.makeStore() })
+
+        await #expect(throws: WidgetTestError.retrieve) {
+            try await loader.eligibleItems()
+        }
+        let items = try await loader.eligibleItems()
+
+        #expect(items == [item])
+        #expect(factory.openCallCount == 2)
+        #expect(await failingStore.retrieveCallCount == 1)
+        #expect(await succeedingStore.retrieveCallCount == 1)
+    }
+
+    @Test
+    func suggestedEntities_returnEmptyOnFailureThenReturnEligibleCodesAfterRetry() async throws {
+        let item = makeOTPVaultItem(accountName: "account", issuer: "issuer")
+        let store = FakeVaultStoreReader(results: [.success(.init(items: [item]))])
+        let factory = StoreFactoryScript(results: [
+            .failure(.open),
+            .success(store),
+        ])
+        let query = OTPWidgetItemEntityQuery(loader: WidgetVaultLoader(makeStore: { try factory.makeStore() }))
+
+        let firstResult = try await query.suggestedEntities()
+        let secondResult = try await query.suggestedEntities()
+
+        #expect(firstResult == [])
+        #expect(secondResult == [
+            OTPWidgetItemEntity(
+                id: item.id.rawValue,
+                issuer: "issuer",
+                accountName: "account",
+            ),
+        ])
+        #expect(factory.openCallCount == 2)
+    }
+
+    @Test
+    func entitiesForIdentifiers_returnEmptyOnFailure() async throws {
+        let id = UUID()
+        let query = OTPWidgetItemEntityQuery(loader: WidgetVaultLoader(makeStore: {
+            throw WidgetTestError.open
+        }))
+
+        let entities = try await query.entities(for: [id])
+
+        #expect(entities == [])
+    }
+
+    @Test
+    func eligibleItems_filtersIneligibleItems() async throws {
+        let eligible = makeOTPVaultItem(accountName: "eligible")
+        let store = FakeVaultStoreReader(results: [.success(.init(items: [
+            eligible,
+            makeOTPVaultItem(accountName: "locked", lockState: .lockedWithNativeSecurity),
+            makeOTPVaultItem(accountName: "hidden", visibility: .onlySearch),
+            makeOTPVaultItem(accountName: "passphrase", searchableLevel: .onlyPassphrase),
+            makeOTPVaultItem(
+                accountName: "killphrase",
+                killphrase: .init(salt: Data([1]), digest: Data([2])),
+            ),
+            makeSecureNoteVaultItem(),
+        ]))])
+        let loader = WidgetVaultLoader(store: store)
+
+        let items = try await loader.eligibleItems()
+
+        #expect(items == [eligible])
+    }
+
+    @Test
+    func providerTimeline_isUnavailableWhenSelectionIsMissing() async {
+        let provider = OTPWidgetProvider(loader: WidgetVaultLoader(store: FakeVaultStoreReader(results: [])))
+
+        let timeline = await provider.makeTimeline(for: .init(item: nil))
+
+        #expect(timeline.entries.first?.snapshot == .unavailable)
+    }
+
+    @Test
+    func providerTimeline_isUnavailableWhenSelectedItemFailsToLoad() async {
+        let entity = OTPWidgetItemEntity(id: UUID(), issuer: "issuer", accountName: "account")
+        let provider = OTPWidgetProvider(loader: WidgetVaultLoader(store: FakeVaultStoreReader(results: [
+            .failure(.retrieve),
+        ])))
+
+        let timeline = await provider.makeTimeline(for: .init(item: entity))
+
+        #expect(timeline.entries.first?.snapshot == .unavailable)
+    }
+}
+
+private enum WidgetTestError: Error, Equatable, Sendable {
+    case open
+    case retrieve
+}
+
+// Test-only synchronous factory. `WidgetVaultLoader.StoreFactory` is synchronous,
+// so actor isolation cannot model its scripted open sequence.
+// swiftlint:disable:next no_unchecked_sendable
+private final class StoreFactoryScript: @unchecked Sendable {
+    enum Result: Sendable {
+        case failure(WidgetTestError)
+        case success(any VaultStoreReader)
+    }
+
+    private var results: [Result]
+    private(set) var openCallCount = 0
+
+    init(results: [Result]) {
+        self.results = results
+    }
+
+    func makeStore() throws -> any VaultStoreReader {
+        openCallCount += 1
+        let result = results.isEmpty ? .failure(.open) : results.removeFirst()
+        switch result {
+        case let .failure(error):
+            throw error
+        case let .success(store):
+            return store
+        }
+    }
+}
+
+private actor FakeVaultStoreReader: VaultStoreReader {
+    private var results: [Result<VaultRetrievalResult<VaultItem>, WidgetTestError>]
+    private(set) var retrieveCallCount = 0
+
+    init(results: [Result<VaultRetrievalResult<VaultItem>, WidgetTestError>]) {
+        self.results = results
+    }
+
+    func retrieve(
+        query _: VaultStoreQuery,
+        searchPassphraseMatcher _: (any SearchPassphraseMatcher)?,
+    ) async throws -> VaultRetrievalResult<VaultItem> {
+        retrieveCallCount += 1
+        let result = results.isEmpty ? .success(.empty()) : results.removeFirst()
+        switch result {
+        case let .success(items):
+            return items
+        case let .failure(error):
+            throw error
+        }
+    }
+
+    var hasAnyItems: Bool {
+        get async throws { true }
+    }
+}
+
+private func makeOTPVaultItem(
+    id: Identifier<VaultItem> = .new(),
+    accountName: String = "",
+    issuer: String = "",
+    visibility: VaultItemVisibility = .always,
+    searchableLevel: VaultItemSearchableLevel = .full,
+    killphrase: KillphraseDigest? = nil,
+    lockState: VaultItemLockState = .notLocked,
+) -> VaultItem {
+    makeVaultItem(
+        id: id,
+        item: .otpCode(.init(
+            type: .totp(),
+            data: .init(
+                secret: .init(data: Data(repeating: 1, count: 20), format: .base32),
+                accountName: accountName,
+                issuer: issuer,
+            ),
+        )),
+        visibility: visibility,
+        searchableLevel: searchableLevel,
+        killphrase: killphrase,
+        lockState: lockState,
+    )
+}
+
+private func makeSecureNoteVaultItem() -> VaultItem {
+    makeVaultItem(item: .secureNote(.init(title: "note", contents: "contents", format: .plain)))
+}
+
+private func makeVaultItem(
+    id: Identifier<VaultItem> = .new(),
+    item: VaultItem.Payload,
+    visibility: VaultItemVisibility = .always,
+    searchableLevel: VaultItemSearchableLevel = .full,
+    killphrase: KillphraseDigest? = nil,
+    lockState: VaultItemLockState = .notLocked,
+) -> VaultItem {
+    let date = Date(timeIntervalSince1970: 0)
+    return VaultItem(
+        metadata: .init(
+            id: id,
+            created: date,
+            updated: date,
+            relativeOrder: 0,
+            userDescription: "",
+            tags: [],
+            visibility: visibility,
+            searchableLevel: searchableLevel,
+            searchPassphrase: nil,
+            killphrase: killphrase,
+            lockState: lockState,
+            color: nil,
+            showInQuickType: true,
+            previewMode: .titleAndFirstLine,
+        ),
+        item: item,
+    )
+}


### PR DESCRIPTION
## Summary

- Add a non-recovering vault store open mode so widget/AppIntent reads never archive or move the shared SQLite store on transient failures.
- Make the OTP widget loader lazy and retry-safe by caching only successful opens and clearing the cache after retrieval failures.
- Keep widget edit-mode resilient by returning an empty picker list on load failure instead of failing the AppIntent query.
- Add widget tests to iOS CI coverage.

## Root Cause

The widget process eagerly opened and cached its own SwiftData store. A first-open failure could leave the widget stuck without retrying, and the shared store factory recovery path was too dangerous for extension reads because it could treat transient open failures like corruption recovery.

## Validation

- `make format`
- `make lint`
- `xcodebuild test -workspace /Users/bradley/Developer/vault-ios/Vault.xcworkspace -scheme CI_iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing:VaultiOSWidgetsTests`
- `xcodebuild test -workspace /Users/bradley/Developer/vault-ios/Vault.xcworkspace -scheme CI_iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -only-testing:VaultFeedTests/PersistedLocalVaultStoreFactoryTests`
