### PR TITLE
Update Swift lint and format tooling

### DIFF
--- a/Vault.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vault.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3bd9d0a4d6e45062763c48180a9c3cf5c02e53bf15d5bcc4d19f9cfe43ae30d9",
+  "originHash" : "332cf84c951ee0268d8ce5668c10a80018712bea3a79b059460d0f3e8b0b61ae",
   "pins" : [
     {
       "identity" : "bigint",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
-        "version" : "0.63.2"
+        "revision" : "18d8d2d18e1668006d1d209e0b5f5e06c1da7cb5",
+        "version" : "0.63.3"
       }
     },
     {

--- a/Vault/.swiftformat
+++ b/Vault/.swiftformat
@@ -27,6 +27,7 @@
 --self remove
 --semicolons inline
 --stripunusedargs always
+--test-case-name-format preserve
 --trailing-commas always
 --trimwhitespace always
 --voidtype void

--- a/Vault/Package.resolved
+++ b/Vault/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "98ca4e60f6e58fbb563ff924fafb683b1f634875d8280fc24ece681f2e4407ee",
+  "originHash" : "332cf84c951ee0268d8ce5668c10a80018712bea3a79b059460d0f3e8b0b61ae",
   "pins" : [
     {
       "identity" : "bigint",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
       "state" : {
-        "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
-        "version" : "0.63.2"
+        "revision" : "18d8d2d18e1668006d1d209e0b5f5e06c1da7cb5",
+        "version" : "0.63.3"
       }
     },
     {

--- a/Vault/Package.swift
+++ b/Vault/Package.swift
@@ -300,7 +300,6 @@ let package = Package(
         .testTarget(
             name: "VaultiOSWidgetsTests",
             dependencies: ["VaultiOSWidgets", "VaultiOSShared", "VaultCore", "VaultFeed", "TestHelpers"],
-            exclude: ["__Snapshots__"],
             swiftSettings: swiftSettings,
             plugins: testTargetPlugins,
         ),

--- a/Vault/Package.swift
+++ b/Vault/Package.swift
@@ -3,9 +3,9 @@
 import CompilerPluginSupport
 import PackageDescription
 
-let swiftLintVersion: Version = "0.63.2"
-let swiftFormatVersion: Version = "0.58.6"
-let swiftFormatChecksum: String = "d2ee571b3f15c173b1789b82b9fcf1e799cff66de0ae9f6839bd35aa8e9b9608"
+let swiftLintVersion: Version = "0.63.3"
+let swiftFormatVersion: Version = "0.61.1"
+let swiftFormatChecksum: String = "47f7932f35c714b00430f56df1cfaf1bea0b4baae299bb2a09874cb52ee45350"
 
 let swiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),

--- a/Vault/Sources/CryptoEngine/DigestHasher.swift
+++ b/Vault/Sources/CryptoEngine/DigestHasher.swift
@@ -1,5 +1,5 @@
-import Foundation
 internal import CryptoSwift
+import Foundation
 
 /// Produces hashes of data.
 public struct DigestHasher {

--- a/Vault/Sources/CryptoEngine/Key Derivation/CombinationKeyDeriver.swift
+++ b/Vault/Sources/CryptoEngine/Key Derivation/CombinationKeyDeriver.swift
@@ -4,7 +4,7 @@ import FoundationExtensions
 /// A key deriver that is composed of a sequence of other `KeyDeriver`s
 ///
 /// The output from the first is fed into the second, etc.
-public struct CombinationKeyDeriver< let bytes: Int>: KeyDeriver {
+public struct CombinationKeyDeriver<let bytes: Int>: KeyDeriver {
     private let derivers: [any KeyDeriver<KeyData<bytes>>]
 
     public init(derivers: [any KeyDeriver<KeyData<bytes>>]) {

--- a/Vault/Sources/CryptoEngine/Key Derivation/HKDFKeyDeriver.swift
+++ b/Vault/Sources/CryptoEngine/Key Derivation/HKDFKeyDeriver.swift
@@ -1,8 +1,8 @@
+internal import CryptoSwift
 import Foundation
 import FoundationExtensions
-internal import CryptoSwift
 
-public struct HKDFKeyDeriver< let bytes: Int>: KeyDeriver {
+public struct HKDFKeyDeriver<let bytes: Int>: KeyDeriver {
     private let parameters: Parameters
 
     public init(parameters: Parameters) {

--- a/Vault/Sources/CryptoEngine/Key Derivation/KeyDeriver.swift
+++ b/Vault/Sources/CryptoEngine/Key Derivation/KeyDeriver.swift
@@ -17,7 +17,7 @@ public protocol KeyDeriver<Key>: Sendable {
 
 // MARK: - Helpers
 
-public struct FailingKeyDeriver< let bytes: Int>: KeyDeriver {
+public struct FailingKeyDeriver<let bytes: Int>: KeyDeriver {
     public init() {}
 
     public struct KeyDeriverError: Error {}
@@ -31,9 +31,12 @@ public struct FailingKeyDeriver< let bytes: Int>: KeyDeriver {
 }
 
 /// A key deriver that is able to signal when derivation started.
-public struct SuspendingKeyDeriver< let bytes: Int>: KeyDeriver {
+public struct SuspendingKeyDeriver<let bytes: Int>: KeyDeriver {
     public typealias Handler = @Sendable (Data, Data) throws -> KeyData<bytes>
-    public var uniqueAlgorithmIdentifier: String { "suspending" }
+    public var uniqueAlgorithmIdentifier: String {
+        "suspending"
+    }
+
     public var handler: Handler
 
     private let waiter = DispatchSemaphore(value: 0)

--- a/Vault/Sources/CryptoEngine/Key Derivation/PBKDF2KeyDeriver.swift
+++ b/Vault/Sources/CryptoEngine/Key Derivation/PBKDF2KeyDeriver.swift
@@ -1,8 +1,8 @@
+internal import CryptoSwift
 import Foundation
 import FoundationExtensions
-internal import CryptoSwift
 
-public struct PBKDF2KeyDeriver< let bytes: Int>: KeyDeriver {
+public struct PBKDF2KeyDeriver<let bytes: Int>: KeyDeriver {
     public let parameters: Parameters
 
     public init(parameters: Parameters) {

--- a/Vault/Sources/CryptoEngine/Key Derivation/ScryptKeyDeriver.swift
+++ b/Vault/Sources/CryptoEngine/Key Derivation/ScryptKeyDeriver.swift
@@ -5,7 +5,7 @@ import FoundationExtensions
 /// Derives keys using the *scrypt* algorithm.
 ///
 /// https://en.wikipedia.org/wiki/Scrypt
-public struct ScryptKeyDeriver< let bytes: Int>: KeyDeriver {
+public struct ScryptKeyDeriver<let bytes: Int>: KeyDeriver {
     public let parameters: Parameters
 
     public init(parameters: Parameters) {

--- a/Vault/Sources/FoundationExtensions/Defaults.swift
+++ b/Vault/Sources/FoundationExtensions/Defaults.swift
@@ -86,8 +86,7 @@ public final class Defaults {
         }
 
         let decoder = JSONDecoder()
-        let decoded = try? decoder.decode(ValueType.self, from: data)
-        return decoded
+        return try? decoder.decode(ValueType.self, from: data)
     }
 
     /// Sets a value associated with the specified key.

--- a/Vault/Sources/FoundationExtensions/IdentifiableSelf.swift
+++ b/Vault/Sources/FoundationExtensions/IdentifiableSelf.swift
@@ -3,5 +3,7 @@ public protocol IdentifiableSelf: Identifiable where Self: Hashable, ID: Hashabl
 }
 
 extension IdentifiableSelf {
-    public var id: Self { self }
+    public var id: Self {
+        self
+    }
 }

--- a/Vault/Sources/FoundationExtensions/Identifier.swift
+++ b/Vault/Sources/FoundationExtensions/Identifier.swift
@@ -23,11 +23,7 @@ extension Identifier: RawRepresentable {
     }
 }
 
-extension Identifier: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.id == rhs.id
-    }
-}
+extension Identifier: Equatable {}
 
 extension Identifier: Hashable {
     public func hash(into hasher: inout Hasher) {

--- a/Vault/Sources/FoundationExtensions/KeyData.swift
+++ b/Vault/Sources/FoundationExtensions/KeyData.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A key that is generic over a specific byte length.
-public struct KeyData< let bytes: Int>: Equatable, Hashable, Sendable {
+public struct KeyData<let bytes: Int>: Equatable, Hashable, Sendable {
     public let data: Data
 
     public struct LengthError: Error {}
@@ -26,7 +26,9 @@ extension KeyData: Codable {
 }
 
 extension KeyData {
-    public static var length: Int { bytes }
+    public static var length: Int {
+        bytes
+    }
 
     public static func zero() -> Self {
         .repeating(byte: 0x00)

--- a/Vault/Sources/TestHelpersMacros/LeakTrackedMacro.swift
+++ b/Vault/Sources/TestHelpersMacros/LeakTrackedMacro.swift
@@ -57,6 +57,11 @@ private struct SimpleDiagnostic: DiagnosticMessage {
         self.message = message
     }
 
-    var diagnosticID: MessageID { MessageID(domain: "TestHelpersMacros", id: "LeakTracked") }
-    var severity: DiagnosticSeverity { .error }
+    var diagnosticID: MessageID {
+        MessageID(domain: "TestHelpersMacros", id: "LeakTracked")
+    }
+
+    var severity: DiagnosticSeverity {
+        .error
+    }
 }

--- a/Vault/Sources/VaultBackup/BackupEncoder/VaultBackupDecryptor.swift
+++ b/Vault/Sources/VaultBackup/BackupEncoder/VaultBackupDecryptor.swift
@@ -35,11 +35,10 @@ public final class VaultBackupDecryptor {
         } error: {
             Error.decryptionFailed($0)
         }
-        let backupPayload = try withMappedError {
+        return try withMappedError {
             try IntermediateEncodedVaultDecoder().decode(encodedVault: encodedVault)
         } error: {
             Error.decodingFailed($0)
         }
-        return backupPayload
     }
 }

--- a/Vault/Sources/VaultBackup/Export/VaultExportPDFDocumentRenderer.swift
+++ b/Vault/Sources/VaultBackup/Export/VaultExportPDFDocumentRenderer.swift
@@ -6,9 +6,8 @@ import VaultExport
 /// A renderer for an exported vault.
 ///
 /// Internally uses a data block renderer to render the data to a PDF.
-struct VaultExportPDFDocumentRenderer<Renderer>: PDFDocumentRenderer
+struct VaultExportPDFDocumentRenderer<Renderer: PDFDocumentRenderer>: PDFDocumentRenderer
     where
-    Renderer: PDFDocumentRenderer,
     Renderer.Document == DataBlockDocument
 {
     typealias Document = VaultExportPayload

--- a/Vault/Sources/VaultCore/Base32/Base32.swift
+++ b/Vault/Sources/VaultCore/Base32/Base32.swift
@@ -75,7 +75,7 @@ public func base32HexDecode(_ string: String) throws(Base32Error) -> [UInt8] {
 // MARK: extensions
 
 extension String {
-    // base32
+    /// base32
     public var base32DecodedData: Data {
         get throws(Base32Error) {
             try base32DecodeToData(self)
@@ -93,7 +93,7 @@ extension String {
         return String(data: data, encoding: .utf8)
     }
 
-    // base32Hex
+    /// base32Hex
     public var base32HexDecodedData: Data {
         get throws(Base32Error) {
             try base32HexDecodeToData(self)
@@ -113,7 +113,7 @@ extension String {
 }
 
 extension Data {
-    // base32
+    /// base32
     public var base32EncodedString: String {
         base32Encode(self)
     }
@@ -128,7 +128,7 @@ extension Data {
         }
     }
 
-    // base32Hex
+    /// base32Hex
     public var base32HexEncodedString: String {
         base32HexEncode(self)
     }
@@ -350,7 +350,7 @@ private func base32decode(_ string: String, _ table: [UInt8]) throws(Base32Error
         return []
     }
 
-    // calc padding length
+    /// calc padding length
     func getLeastPaddingLength(_ string: String) -> Int {
         if string.hasSuffix("======") {
             6

--- a/Vault/Sources/VaultCore/OTPAuthCodeData.swift
+++ b/Vault/Sources/VaultCore/OTPAuthCodeData.swift
@@ -73,7 +73,9 @@ extension OTPAuthDigits: ExpressibleByIntegerLiteral {
 }
 
 extension OTPAuthDigits {
-    public static var `default`: OTPAuthDigits { .init(value: 6) }
+    public static var `default`: OTPAuthDigits {
+        .init(value: 6)
+    }
 }
 
 public enum OTPAuthAlgorithm: Equatable, Hashable, IdentifiableSelf, CaseIterable, Sendable {
@@ -81,7 +83,9 @@ public enum OTPAuthAlgorithm: Equatable, Hashable, IdentifiableSelf, CaseIterabl
     case sha256
     case sha512
 
-    public static var `default`: OTPAuthAlgorithm { .sha1 }
+    public static var `default`: OTPAuthAlgorithm {
+        .sha1
+    }
 
     public var stringValue: String {
         switch self {
@@ -97,11 +101,15 @@ public enum OTPAuthType: Equatable, Hashable, Sendable {
     case hotp(counter: UInt64 = HOTP.defaultCounter)
 
     public enum TOTP {
-        public static var defaultPeriod: UInt64 { 30 }
+        public static var defaultPeriod: UInt64 {
+            30
+        }
     }
 
     public enum HOTP {
-        public static var defaultCounter: UInt64 { 0 }
+        public static var defaultCounter: UInt64 {
+            0
+        }
     }
 
     public enum Kind: Equatable, Hashable, IdentifiableSelf, CaseIterable, Sendable {

--- a/Vault/Sources/VaultExport/PDF/PDFDocumentSize.swift
+++ b/Vault/Sources/VaultExport/PDF/PDFDocumentSize.swift
@@ -36,7 +36,7 @@ extension PDFDocumentSize {
         )
     }
 
-    /// The size of the margins in pixels, given the `pointsPerInch`.
+    // The size of the margins in pixels, given the `pointsPerInch`.
 
     /// The number of squares most appropriate for the size of the paper.
     ///

--- a/Vault/Sources/VaultFeed/Authentication/DeviceAuthenticationPolicy.swift
+++ b/Vault/Sources/VaultFeed/Authentication/DeviceAuthenticationPolicy.swift
@@ -32,8 +32,13 @@ extension DeviceAuthenticationPolicy {
 public struct DeviceAuthenticationPolicyAlwaysDeny: DeviceAuthenticationPolicy {
     public init() {}
 
-    public var canAuthenicateWithPasscode: Bool { true }
-    public var canAuthenticateWithBiometrics: Bool { true }
+    public var canAuthenicateWithPasscode: Bool {
+        true
+    }
+
+    public var canAuthenticateWithBiometrics: Bool {
+        true
+    }
 
     public func authenticateWithPasscode(reason _: String) async throws -> Bool {
         false
@@ -45,14 +50,21 @@ public struct DeviceAuthenticationPolicyAlwaysDeny: DeviceAuthenticationPolicy {
 }
 
 extension DeviceAuthenticationPolicy where Self == DeviceAuthenticationPolicyAlwaysDeny {
-    public static var alwaysDeny: Self { .init() }
+    public static var alwaysDeny: Self {
+        .init()
+    }
 }
 
 public struct DeviceAuthenticationPolicyCannotAuthenticate: DeviceAuthenticationPolicy {
     public init() {}
 
-    public var canAuthenicateWithPasscode: Bool { false }
-    public var canAuthenticateWithBiometrics: Bool { false }
+    public var canAuthenicateWithPasscode: Bool {
+        false
+    }
+
+    public var canAuthenticateWithBiometrics: Bool {
+        false
+    }
 
     public func authenticateWithPasscode(reason _: String) async throws -> Bool {
         false
@@ -64,14 +76,21 @@ public struct DeviceAuthenticationPolicyCannotAuthenticate: DeviceAuthentication
 }
 
 extension DeviceAuthenticationPolicy where Self == DeviceAuthenticationPolicyCannotAuthenticate {
-    public static var cannotAuthenticate: Self { .init() }
+    public static var cannotAuthenticate: Self {
+        .init()
+    }
 }
 
 public struct DeviceAuthenticationPolicyAlwaysAllow: DeviceAuthenticationPolicy {
     public init() {}
 
-    public var canAuthenicateWithPasscode: Bool { true }
-    public var canAuthenticateWithBiometrics: Bool { true }
+    public var canAuthenicateWithPasscode: Bool {
+        true
+    }
+
+    public var canAuthenticateWithBiometrics: Bool {
+        true
+    }
 
     public func authenticateWithPasscode(reason _: String) async throws -> Bool {
         true
@@ -83,7 +102,9 @@ public struct DeviceAuthenticationPolicyAlwaysAllow: DeviceAuthenticationPolicy 
 }
 
 extension DeviceAuthenticationPolicy where Self == DeviceAuthenticationPolicyAlwaysAllow {
-    public static var alwaysAllow: Self { .init() }
+    public static var alwaysAllow: Self {
+        .init()
+    }
 }
 
 /// `DeviceAuthenticationPolicy` using `LocalAuthentication`.
@@ -123,6 +144,11 @@ public struct DeviceAuthenticationPolicyUsingDevice: DeviceAuthenticationPolicy 
 }
 
 extension DeviceAuthenticationPolicy where Self == DeviceAuthenticationPolicyUsingDevice {
-    public static var `default`: Self { .init() }
-    public static var usingDevice: Self { .init() }
+    public static var `default`: Self {
+        .init()
+    }
+
+    public static var usingDevice: Self {
+        .init()
+    }
 }

--- a/Vault/Sources/VaultFeed/CodeScanner/BackupImportScanningHandler.swift
+++ b/Vault/Sources/VaultFeed/CodeScanner/BackupImportScanningHandler.swift
@@ -57,8 +57,7 @@ public final class BackupImportScanningHandler: CodeScanningHandler {
 
     private func decodeEncryptedVault() throws -> EncryptedVault {
         let encryptedVaultData = try shardDecoder.decodeData()
-        let decodedEncryptedVault = try EncryptedVaultCoder().decode(vaultData: encryptedVaultData)
-        return decodedEncryptedVault
+        return try EncryptedVaultCoder().decode(vaultData: encryptedVaultData)
     }
 }
 

--- a/Vault/Sources/VaultFeed/CodeScanner/OTPCodeScanningHandler.swift
+++ b/Vault/Sources/VaultFeed/CodeScanner/OTPCodeScanningHandler.swift
@@ -17,7 +17,9 @@ public final class OTPCodeScanningHandler: CodeScanningHandler {
         }
     }
 
-    public var hasPartialState: Bool { false }
+    public var hasPartialState: Bool {
+        false
+    }
 
     public func makeSimulatedHandler() -> some SimulatedCodeScanningHandler<OTPAuthCode> {
         SimulatedOTPCodeScanningHandler()

--- a/Vault/Sources/VaultFeed/Models/VaultBackupEvent.swift
+++ b/Vault/Sources/VaultFeed/Models/VaultBackupEvent.swift
@@ -48,7 +48,7 @@ extension VaultBackupEvent {
             }
         }
 
-        // Custom Codable for backwards compatibility
+        /// Custom Codable for backwards compatibility
         private enum CodingKeys: String, CodingKey {
             case type
             case providerID

--- a/Vault/Sources/VaultFeed/Models/VaultDateFormatter.swift
+++ b/Vault/Sources/VaultFeed/Models/VaultDateFormatter.swift
@@ -7,9 +7,8 @@ public struct VaultDateFormatter {
     }
 
     public func formatForFileName(date: Date) -> String {
-        let corrected = formatter.string(from: date)
+        formatter.string(from: date)
             .replacingOccurrences(of: ":", with: "-") // colons not supported in filenames
-        return corrected
     }
 
     private var formatter: ISO8601DateFormatter {

--- a/Vault/Sources/VaultFeed/Presentation/Backup/BackupKeyDecryptorViewModel.swift
+++ b/Vault/Sources/VaultFeed/Presentation/Backup/BackupKeyDecryptorViewModel.swift
@@ -65,8 +65,13 @@ public final class BackupKeyDecryptorViewModel {
     }
 
     private struct MissingPasswordError: Error, LocalizedError {
-        var errorDescription: String? { "Password Required" }
-        var failureReason: String? { "The password cannot be empty" }
+        var errorDescription: String? {
+            "Password Required"
+        }
+
+        var failureReason: String? {
+            "The password cannot be empty"
+        }
     }
 
     public var canAttemptDecryption: Bool {

--- a/Vault/Sources/VaultFeed/Presentation/PresentationError.swift
+++ b/Vault/Sources/VaultFeed/Presentation/PresentationError.swift
@@ -20,6 +20,11 @@ public struct PresentationError: Error, Equatable, Hashable {
 }
 
 extension PresentationError: LocalizedError {
-    public var errorDescription: String? { userTitle }
-    public var failureReason: String? { userDescription }
+    public var errorDescription: String? {
+        userTitle
+    }
+
+    public var failureReason: String? {
+        userDescription
+    }
 }

--- a/Vault/Sources/VaultFeed/Storage/Backup/AutoBackup/Providers/iCloudDriveProvider.swift
+++ b/Vault/Sources/VaultFeed/Storage/Backup/AutoBackup/Providers/iCloudDriveProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Configuration data for the iCloud Drive provider.
-struct iCloudDriveProviderConfiguration: Codable, Equatable, Sendable {
+struct iCloudDriveProviderConfiguration: Codable, Equatable {
     /// Security-scoped bookmark data for the selected folder.
     var folderBookmark: Data?
 
@@ -117,7 +117,7 @@ public actor iCloudDriveProvider: BackupStorageProvider {
             options: [.skipsHiddenFiles],
         )
 
-        let backupFiles = try contents
+        return try contents
             .filter { $0.lastPathComponent.hasPrefix("vault-auto-backup-") }
             .filter { $0.pathExtension.lowercased() == "pdf" }
             .map { url -> BackupFileInfo in
@@ -129,8 +129,6 @@ public actor iCloudDriveProvider: BackupStorageProvider {
                 )
             }
             .sorted { $0.createdDate > $1.createdDate }
-
-        return backupFiles
     }
 
     public func delete(filename: String) async throws {

--- a/Vault/Sources/VaultFeed/Storage/Migration/PendingKillphraseRehashStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/Migration/PendingKillphraseRehashStore.swift
@@ -19,7 +19,7 @@ import Foundation
 /// service. Marked `@unchecked Sendable` so the injected dependency does
 /// not force every caller to wrap it.
 struct PendingKillphraseRehashStore: @unchecked Sendable { // swiftlint:disable:this no_unchecked_sendable
-    struct Entry: Codable, Equatable, Sendable {
+    struct Entry: Codable, Equatable {
         let itemID: UUID
         let phrase: String
     }

--- a/Vault/Sources/VaultFeed/Storage/Migration/PendingSearchPassphraseRehashStore.swift
+++ b/Vault/Sources/VaultFeed/Storage/Migration/PendingSearchPassphraseRehashStore.swift
@@ -20,7 +20,7 @@ import Foundation
 /// Marked `@unchecked Sendable` so the injected dependency does not force
 /// every caller to wrap it.
 struct PendingSearchPassphraseRehashStore: @unchecked Sendable { // swiftlint:disable:this no_unchecked_sendable
-    struct Entry: Codable, Equatable, Sendable {
+    struct Entry: Codable, Equatable {
         let itemID: UUID
         let phrase: String
     }

--- a/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedVaultTagEncoder.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/SwiftData/PersistedVaultTagEncoder.swift
@@ -13,12 +13,11 @@ struct PersistedVaultTagEncoder {
     }
 
     func encode(tag: VaultItemTag.Write, existing: PersistedVaultTag? = nil) -> PersistedVaultTag {
-        let tagItem = if let existing {
+        if let existing {
             encode(existingTag: existing, newData: tag)
         } else {
             encode(newTag: tag)
         }
-        return tagItem
     }
 }
 

--- a/Vault/Sources/VaultFeed/Storage/VaultStore/VaultRetrievalResult.swift
+++ b/Vault/Sources/VaultFeed/Storage/VaultStore/VaultRetrievalResult.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct VaultRetrievalResult<T>: Equatable, Sendable where T: Equatable, T: Sendable {
+public struct VaultRetrievalResult<T: Equatable & Sendable>: Equatable, Sendable {
     public var items: [T]
     public var errors: [Error]
 

--- a/Vault/Sources/VaultKeygen/VaultKeyDeriver.swift
+++ b/Vault/Sources/VaultKeygen/VaultKeyDeriver.swift
@@ -82,8 +82,13 @@ extension VaultKeyDeriver {
 
 extension VaultKeyDeriver {
     public struct MissingKeyDeriverError: Error, LocalizedError {
-        public var errorDescription: String? { "Missing Key Deriver" }
-        public var failureReason: String? { "The key deriver used to generate this key is invalid" }
+        public var errorDescription: String? {
+            "Missing Key Deriver"
+        }
+
+        public var failureReason: String? {
+            "The key deriver used to generate this key is invalid"
+        }
     }
 
     public static func lookup(signature: VaultKeyDeriver.Signature) -> VaultKeyDeriver {

--- a/Vault/Sources/VaultKeygen/VaultKeyDeriverFactory.swift
+++ b/Vault/Sources/VaultKeygen/VaultKeyDeriverFactory.swift
@@ -39,23 +39,43 @@ public struct VaultKeyDeriverFactoryImpl: VaultKeyDeriverFactory {
 /// Always uses and looks up the testing deriver, to ensure that tests run fast.
 public struct VaultKeyDeriverFactoryTesting: VaultKeyDeriverFactory {
     public init() {}
-    public func makeVaultBackupKeyDeriver() -> VaultKeyDeriver { .testing }
-    public func makeVaultItemKeyDeriver() -> VaultKeyDeriver { .testing }
-    public func lookupVaultKeyDeriver(signature _: VaultKeyDeriver.Signature) -> VaultKeyDeriver { .testing }
+    public func makeVaultBackupKeyDeriver() -> VaultKeyDeriver {
+        .testing
+    }
+
+    public func makeVaultItemKeyDeriver() -> VaultKeyDeriver {
+        .testing
+    }
+
+    public func lookupVaultKeyDeriver(signature _: VaultKeyDeriver.Signature) -> VaultKeyDeriver {
+        .testing
+    }
 }
 
 extension VaultKeyDeriverFactory where Self == VaultKeyDeriverFactoryTesting {
-    public static var testing: Self { VaultKeyDeriverFactoryTesting() }
+    public static var testing: Self {
+        VaultKeyDeriverFactoryTesting()
+    }
 }
 
 /// Always uses the key deriver that generates a key generation error.
 public struct VaultKeyDeriverFactoryFailing: VaultKeyDeriverFactory {
     public init() {}
-    public func makeVaultBackupKeyDeriver() -> VaultKeyDeriver { .failing }
-    public func makeVaultItemKeyDeriver() -> VaultKeyDeriver { .failing }
-    public func lookupVaultKeyDeriver(signature _: VaultKeyDeriver.Signature) -> VaultKeyDeriver { .failing }
+    public func makeVaultBackupKeyDeriver() -> VaultKeyDeriver {
+        .failing
+    }
+
+    public func makeVaultItemKeyDeriver() -> VaultKeyDeriver {
+        .failing
+    }
+
+    public func lookupVaultKeyDeriver(signature _: VaultKeyDeriver.Signature) -> VaultKeyDeriver {
+        .failing
+    }
 }
 
 extension VaultKeyDeriverFactory where Self == VaultKeyDeriverFactoryFailing {
-    public static var failing: Self { VaultKeyDeriverFactoryFailing() }
+    public static var failing: Self {
+        VaultKeyDeriverFactoryFailing()
+    }
 }

--- a/Vault/Sources/VaultiOS/VaultRoot.swift
+++ b/Vault/Sources/VaultiOS/VaultRoot.swift
@@ -148,9 +148,9 @@ public enum VaultRoot {
         return repo
     }()
 
-    // Ideally this would just vend the generic `some VaultItemPreviewViewGenerator<VaultItem.Payload>`
-    // But that currently gives us a compiler error (only while archiving?!) so let's vend the full (massive) concrete
-    // type for now :(
+    /// Ideally this would just vend the generic `some VaultItemPreviewViewGenerator<VaultItem.Payload>`
+    /// But that currently gives us a compiler error (only while archiving?!) so let's vend the full (massive) concrete
+    /// type for now :(
     @MainActor
     public static let genericVaultItemPreviewViewGenerator =
         GenericVaultItemPreviewViewGenerator(

--- a/Vault/Sources/VaultiOS/Views/Backup/BackupGeneratedPDFView.swift
+++ b/Vault/Sources/VaultiOS/Views/Backup/BackupGeneratedPDFView.swift
@@ -58,7 +58,9 @@ struct BackupGeneratedPDFView: View {
         let index: Int
         let document: PDFDocument
         let totalPages: Int
-        var id: Int { index }
+        var id: Int {
+            index
+        }
     }
 
     private var pdfPreviewSection: some View {

--- a/Vault/Sources/VaultiOS/Views/General/Color+Constrast.swift
+++ b/Vault/Sources/VaultiOS/Views/General/Color+Constrast.swift
@@ -16,12 +16,12 @@ extension Color {
         return 0.0
     }
 
-    // Determine appropriate foreground color for contrast
+    /// Determine appropriate foreground color for contrast
     var contrastingForegroundColor: Color {
         isPercievedLight ? .black.opacity(0.8) : .white
     }
 
-    // Determine appropriate foreground color for contrast
+    /// Determine appropriate foreground color for contrast
     var contrastingBackgroudColor: Color {
         isPercievedLight ? .primary.opacity(0.8) : Color(UIColor.systemBackground).opacity(0.8)
     }

--- a/Vault/Sources/VaultiOS/Views/General/LiteratureView.swift
+++ b/Vault/Sources/VaultiOS/Views/General/LiteratureView.swift
@@ -9,12 +9,6 @@ struct LiteratureView: View {
     var bodyText: FormattedString
     var bodyColor: Color
 
-    init(title: String, bodyText: FormattedString, bodyColor: Color) {
-        self.title = title
-        self.bodyText = bodyText
-        self.bodyColor = bodyColor
-    }
-
     var body: some View {
         ScrollView(.vertical, showsIndicators: true) {
             VStack(alignment: .leading) {

--- a/Vault/Sources/VaultiOS/Views/General/SelectableTextView.swift
+++ b/Vault/Sources/VaultiOS/Views/General/SelectableTextView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import UIKit
 
 final class SelectableTextView: UITextView {
-    // change the cursor to have zero size
+    /// change the cursor to have zero size
     override func caretRect(for _: UITextPosition) -> CGRect {
         .zero
     }

--- a/Vault/Sources/VaultiOS/Views/General/Shimmer.swift
+++ b/Vault/Sources/VaultiOS/Views/General/Shimmer.swift
@@ -57,7 +57,7 @@ public struct Shimmer: ViewModifier {
     /// The default animation effect.
     public static let defaultAnimation = Animation.linear(duration: 1.5).delay(0.25).repeatForever(autoreverses: false)
 
-    // A default gradient for the animated mask.
+    /// A default gradient for the animated mask.
     public static let defaultGradient = Gradient(colors: [
         .black.opacity(0.3), // translucent
         .black, // opaque

--- a/Vault/Sources/VaultiOS/Views/General/TextArea.swift
+++ b/Vault/Sources/VaultiOS/Views/General/TextArea.swift
@@ -23,7 +23,7 @@ struct TextArea: UIViewRepresentable {
         Coordinator(text: $text)
     }
 
-    // Coordinator to handle UITextViewDelegate events
+    /// Coordinator to handle UITextViewDelegate events
     class Coordinator: NSObject, UITextViewDelegate {
         @Binding var text: String
 

--- a/Vault/Sources/VaultiOS/Views/Previews/VaultCardModifier.swift
+++ b/Vault/Sources/VaultiOS/Views/Previews/VaultCardModifier.swift
@@ -14,10 +14,6 @@ struct VaultCardModifier: ViewModifier {
     }
 
     var configuration: Configuration
-    init(configuration: Configuration) {
-        self.configuration = configuration
-    }
-
     func body(content: Content) -> some View {
         content
             .padding(configuration.padding)

--- a/Vault/Sources/VaultiOSAutofill/VaultCredentialProviderViewController.swift
+++ b/Vault/Sources/VaultiOSAutofill/VaultCredentialProviderViewController.swift
@@ -56,11 +56,11 @@ open class VaultCredentialProviderViewController: ASCredentialProviderViewContro
         }.store(in: &cancellables)
     }
 
-    // This function is called when autofill is initially enabled.
-    // It allows configuration before enable.
-    // It's not required, but would be good to do some config here.
-    //
-    // It's triggered by the "ASCredentialProviderExtensionShowsConfigurationUI" key in the Info.plist
+    /// This function is called when autofill is initially enabled.
+    /// It allows configuration before enable.
+    /// It's not required, but would be good to do some config here.
+    ///
+    /// It's triggered by the "ASCredentialProviderExtensionShowsConfigurationUI" key in the Info.plist
     override open func prepareInterfaceForExtensionConfiguration() {
         super.prepareInterfaceForExtensionConfiguration()
 
@@ -73,7 +73,7 @@ open class VaultCredentialProviderViewController: ASCredentialProviderViewContro
         vaultAutofillViewModel.show(feature: .setupConfiguration)
     }
 
-    /*
+    /**
      Implement this method if your extension supports showing credentials in the QuickType bar.
      When the user selects a credential from your app, this method will be called with the
      ASPasswordCredentialIdentity your app has previously saved to the ASCredentialIdentityStore.
@@ -145,7 +145,7 @@ open class VaultCredentialProviderViewController: ASCredentialProviderViewContro
         }
     }
 
-    /*
+    /**
      Implement this method if provideCredentialWithoutUserInteraction(for:) can fail with
      ASExtensionError.userInteractionRequired. In this case, the system may present your extension's
      UI and call this method. Show appropriate UI for authenticating the user then provide the password
@@ -159,7 +159,7 @@ open class VaultCredentialProviderViewController: ASCredentialProviderViewContro
         vaultAutofillViewModel.show(feature: .showAllCodesSelector)
     }
 
-    /*! @abstract Prepare the view controller to show a list of one time code credentials.
+    /** ! @abstract Prepare the view controller to show a list of one time code credentials.
      @param serviceIdentifiers the array of service identifiers.
      @discussion This method is called by the system to prepare the extension's view controller to present the list of credentials.
      A service identifier array is passed which can be used to filter or prioritize the credentials that closely match each service.
@@ -178,7 +178,7 @@ open class VaultCredentialProviderViewController: ASCredentialProviderViewContro
         vaultAutofillViewModel.show(feature: .showAllCodesSelector)
     }
 
-    /*
+    /**
      This method is called by the system to prepare the extension's view controller to present the list of credentials.
      A service identifier array is passed which can be used to filter or prioritize the credentials that closely match each service.
      The service identifier array could have zero or more items. If there are more than one item in the array, items with lower indexes

--- a/Vault/Sources/VaultiOSAutofill/Views/VaultAutofillCodeSelectorView.swift
+++ b/Vault/Sources/VaultiOSAutofill/Views/VaultAutofillCodeSelectorView.swift
@@ -13,20 +13,6 @@ struct VaultAutofillCodeSelectorView<Generator: VaultItemPreviewViewGenerator<Va
     let textToInsertSubject: PassthroughSubject<String, Never>
     let cancelSubject: PassthroughSubject<VaultAutofillViewModel.RequestCancelReason, Never>
 
-    init(
-        localSettings: LocalSettings,
-        viewGenerator: Generator,
-        copyActionHandler: any VaultItemCopyActionHandler,
-        textToInsertSubject: PassthroughSubject<String, Never>,
-        cancelSubject: PassthroughSubject<VaultAutofillViewModel.RequestCancelReason, Never>,
-    ) {
-        self.localSettings = localSettings
-        self.viewGenerator = viewGenerator
-        self.copyActionHandler = copyActionHandler
-        self.textToInsertSubject = textToInsertSubject
-        self.cancelSubject = cancelSubject
-    }
-
     @Environment(VaultDataModel.self) private var dataModel
     @Environment(DeviceAuthenticationService.self) var authenticationService
     @Environment(\.scenePhase) private var scenePhase

--- a/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetSmallView.swift
+++ b/Vault/Sources/VaultiOSWidgets/Views/OTPWidgetSmallView.swift
@@ -31,7 +31,6 @@ struct OTPWidgetSmallView: View {
 
     // MARK: - Pieces
 
-    @ViewBuilder
     private var icon: some View {
         Image(systemName: "key.horizontal.fill")
             .font(.caption2.weight(.semibold))

--- a/Vault/Tests/CryptoEngineTests/Key Derivation/CombinationKeyDervierTests.swift
+++ b/Vault/Tests/CryptoEngineTests/Key Derivation/CombinationKeyDervierTests.swift
@@ -71,7 +71,7 @@ struct CombinationKeyDeriverTests {
     }
 
     @Test
-    func key_checksCancellationBetweenAlgs() async throws {
+    func key_checksCancellationBetweenAlgs() async {
         // We expect 3 confirmations, from the first 3 algos, the 4th should not run.
         await confirmation(expectedCount: 3) { confirmation in
             let keyTask = SharedMutex<Task<KeyData<32>, any Error>?>(nil)
@@ -149,7 +149,10 @@ extension CombinationKeyDeriverTests {
             self.signal = signal
         }
 
-        var uniqueAlgorithmIdentifier: String { "signal" }
+        var uniqueAlgorithmIdentifier: String {
+            "signal"
+        }
+
         func key(password _: Data, salt _: Data) throws -> KeyData<32> {
             signal()
             return .zero()

--- a/Vault/Tests/CryptoEngineTests/Key Derivation/HKDFKeyDeriverTests.swift
+++ b/Vault/Tests/CryptoEngineTests/Key Derivation/HKDFKeyDeriverTests.swift
@@ -24,7 +24,7 @@ struct HKDFKeyDeriverTests {
     }
 
     @Test
-    func key_generatesValidKeyWithSalt() async throws {
+    func key_generatesValidKeyWithSalt() throws {
         // https://gchq.github.io/CyberChef/#recipe=Derive_HKDF_key(%7B'option':'Hex','string':'ABCDEF'%7D,%7B'option':'Hex','string':''%7D,'SHA256','with%20salt',8)&input=aGVsbG8gd29ybGQ
         let password = Data(byteString: "hello world")
         let salt = Data(hex: "ABCDEF")

--- a/Vault/Tests/CryptoEngineTests/Key Derivation/PBKDF2KeyDeriverTests.swift
+++ b/Vault/Tests/CryptoEngineTests/Key Derivation/PBKDF2KeyDeriverTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 struct PBKDF2KeyDeriverTests {
     @Test
-    func key_doesNotThrowForValidParameters() async {
+    func key_doesNotThrowForValidParameters() {
         let sut = PBKDF2KeyDeriver<8>(parameters: .fastForTesting)
 
         #expect(throws: Never.self) {
@@ -15,7 +15,7 @@ struct PBKDF2KeyDeriverTests {
     }
 
     @Test
-    func key_throwsIfMissingSalt() async {
+    func key_throwsIfMissingSalt() {
         let sut = PBKDF2KeyDeriver<8>(parameters: .fastForTesting)
 
         #expect(throws: (any Error).self) {
@@ -24,7 +24,7 @@ struct PBKDF2KeyDeriverTests {
     }
 
     @Test
-    func key_generatesValidKeyWithSalt() async throws {
+    func key_generatesValidKeyWithSalt() throws {
         let password = Data(byteString: "hello world")
         let salt = Data(hex: "ABCDEF")
         let sut = PBKDF2KeyDeriver<8>(parameters: .fastForTesting)
@@ -34,7 +34,7 @@ struct PBKDF2KeyDeriverTests {
     }
 
     @Test
-    func key_generatesTheSameKeyMultipleTimes() async throws {
+    func key_generatesTheSameKeyMultipleTimes() throws {
         let password = Data(byteString: "hello world")
         let salt = Data(hex: "ABCDEF")
         let sut = PBKDF2KeyDeriver<8>(parameters: .fastForTesting)

--- a/Vault/Tests/CryptoEngineTests/Key Derivation/ScryptKeyDeriverTests.swift
+++ b/Vault/Tests/CryptoEngineTests/Key Derivation/ScryptKeyDeriverTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 struct ScryptKeyDeriverTests {
     @Test
-    func key_doesNotThrowForValidParameters() async {
+    func key_doesNotThrowForValidParameters() {
         let params = ScryptKeyDeriver<8>.Parameters(
             costFactor: 1 << 4,
             blockSizeFactor: 2,
@@ -21,7 +21,7 @@ struct ScryptKeyDeriverTests {
     }
 
     @Test
-    func key_throwsForInvalidParameters() async {
+    func key_throwsForInvalidParameters() {
         let params = ScryptKeyDeriver<8>.Parameters(
             costFactor: 16385,
             blockSizeFactor: 8,
@@ -35,7 +35,7 @@ struct ScryptKeyDeriverTests {
     }
 
     @Test
-    func key_throwsIfMissingSalt() async {
+    func key_throwsIfMissingSalt() {
         let sut = makeSUT(parameters: .fastForTesting)
 
         #expect(throws: (any Error).self) {
@@ -44,7 +44,7 @@ struct ScryptKeyDeriverTests {
     }
 
     @Test
-    func key_generatesValidKeyWithSalt() async throws {
+    func key_generatesValidKeyWithSalt() throws {
         let password = Data(byteString: "hello world")
         let salt = Data(hex: "ABCDEF")
         let sut = makeSUT(parameters: .fastForTesting)
@@ -54,7 +54,7 @@ struct ScryptKeyDeriverTests {
     }
 
     @Test
-    func key_generatesValidKeyWithEmptyPassword() async throws {
+    func key_generatesValidKeyWithEmptyPassword() throws {
         let password = Data()
         let salt = Data(hex: "ABCDEF")
         let sut = makeSUT(parameters: .fastForTesting)
@@ -64,7 +64,7 @@ struct ScryptKeyDeriverTests {
     }
 
     @Test
-    func key_generatesTheSameKeyMultipleTimes() async throws {
+    func key_generatesTheSameKeyMultipleTimes() throws {
         let password = Data()
         let salt = Data(hex: "ABCDEF")
         let sut = makeSUT(parameters: .fastForTesting)

--- a/Vault/Tests/CryptoEngineTests/Symmetric/AESGCMDecryptorTests.swift
+++ b/Vault/Tests/CryptoEngineTests/Symmetric/AESGCMDecryptorTests.swift
@@ -42,7 +42,7 @@ struct AESGCMDecryptorTests {
     }
 
     @Test
-    func decrypt_throwsErrorIfTagIsBadForNonEmptyMessage() throws {
+    func decrypt_throwsErrorIfTagIsBadForNonEmptyMessage() {
         let key = Data(hex: "0xfeffe9928665731c6d6a8f9467308308")
         let iv = Data(hex: "0xcafebabefacedbaddecaf888")
         let message = AESGCMEncryptedMessage(

--- a/Vault/Tests/FoundationExtensionsTests/AtomicTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/AtomicTests.swift
@@ -38,14 +38,14 @@ struct SharedMutexTests {
     }
 
     @Test(arguments: [1, 2, 3, 100, 12345])
-    func value_getsValue(initialValue: Int) async {
+    func value_getsValue(initialValue: Int) {
         let a = SharedMutex(initialValue)
 
         #expect(a.value == initialValue)
     }
 
     @Test(arguments: [1, 2, 3, 100, 12345])
-    func modify_modifiesExistingValue(initialValue: Int) async {
+    func modify_modifiesExistingValue(initialValue: Int) {
         let a = SharedMutex(initialValue)
 
         a.modify { value in

--- a/Vault/Tests/FoundationExtensionsTests/DefaultsStoredTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/DefaultsStoredTests.swift
@@ -12,7 +12,7 @@ final class DefaultsStoredTests {
     }
 
     @Test(arguments: [0, 1234, 456])
-    func init_fallsBackToDefaultIfNoStoredValue(defaultValue: Int) throws {
+    func init_fallsBackToDefaultIfNoStoredValue(defaultValue: Int) {
         @DefaultsStored(defaults: defaults, defaultsKey: .init("test1"), defaultValue: defaultValue)
         var coolNumber: Int
 

--- a/Vault/Tests/FoundationExtensionsTests/DefaultsTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/DefaultsTests.swift
@@ -207,16 +207,45 @@ final class DefaultTests {
 // MARK: - Helpers
 
 extension DefaultsKey {
-    fileprivate static var integerKey: Key<Int> { .init("integerKey") }
-    fileprivate static var floatKey: Key<Float> { .init("floatKey") }
-    fileprivate static var doubleKey: Key<Double> { .init("doubleKey") }
-    fileprivate static var stringKey: Key<String> { .init("stringKey") }
-    fileprivate static var boolKey: Key<Bool> { .init("boolKey") }
-    fileprivate static var dateKey: Key<Date> { .init("dateKey") }
-    fileprivate static var enumKey: Key<EnumMock> { .init("enumKey") }
-    fileprivate static var optionSetKey: Key<OptionSetMock> { .init("optionSetKey") }
-    fileprivate static var arrayOfIntegersKey: Key<[Int]> { .init("arrayOfIntegersKey") }
-    fileprivate static var personMockKey: Key<PersonMock> { .init("personMockKey") }
+    fileprivate static var integerKey: Key<Int> {
+        .init("integerKey")
+    }
+
+    fileprivate static var floatKey: Key<Float> {
+        .init("floatKey")
+    }
+
+    fileprivate static var doubleKey: Key<Double> {
+        .init("doubleKey")
+    }
+
+    fileprivate static var stringKey: Key<String> {
+        .init("stringKey")
+    }
+
+    fileprivate static var boolKey: Key<Bool> {
+        .init("boolKey")
+    }
+
+    fileprivate static var dateKey: Key<Date> {
+        .init("dateKey")
+    }
+
+    fileprivate static var enumKey: Key<EnumMock> {
+        .init("enumKey")
+    }
+
+    fileprivate static var optionSetKey: Key<OptionSetMock> {
+        .init("optionSetKey")
+    }
+
+    fileprivate static var arrayOfIntegersKey: Key<[Int]> {
+        .init("arrayOfIntegersKey")
+    }
+
+    fileprivate static var personMockKey: Key<PersonMock> {
+        .init("personMockKey")
+    }
 }
 
 struct PersonMock: Codable {

--- a/Vault/Tests/FoundationExtensionsTests/IdentifierTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/IdentifierTests.swift
@@ -24,7 +24,7 @@ struct IdentifierTests {
     }
 
     @Test
-    func init_fromUUID() throws {
+    func init_fromUUID() {
         let fixed = UUID()
         let id = Identifier<Int>(id: fixed)
 
@@ -40,7 +40,7 @@ struct IdentifierTests {
     }
 
     @Test
-    func equatable_equals() throws {
+    func equatable_equals() {
         let fixed = UUID()
         let id1 = Identifier<Int>(id: fixed)
         let id2 = Identifier<Int>(id: fixed)
@@ -49,7 +49,7 @@ struct IdentifierTests {
     }
 
     @Test
-    func hashable_hashesSameIDs() throws {
+    func hashable_hashesSameIDs() {
         var set = Set<Identifier<Int>>()
 
         let fixed = UUID()
@@ -63,7 +63,7 @@ struct IdentifierTests {
     }
 
     @Test
-    func uuidString_creates() throws {
+    func uuidString_creates() {
         let fixed = UUID()
         let id1 = Identifier<Int>.uuidString(fixed.uuidString)
         let id2 = Identifier<Int>(id: fixed)
@@ -72,7 +72,7 @@ struct IdentifierTests {
     }
 
     @Test
-    func map_usesSameIdentifier() throws {
+    func map_usesSameIdentifier() {
         let fixed = UUID()
         let id1 = Identifier<Int>(id: fixed)
         let id2: Identifier<String> = id1.map()
@@ -81,7 +81,7 @@ struct IdentifierTests {
     }
 
     @Test
-    func rawValue_isUUID() throws {
+    func rawValue_isUUID() {
         let fixed = UUID()
         let id1 = Identifier<Int>(id: fixed)
 

--- a/Vault/Tests/FoundationExtensionsTests/KeyDataTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/KeyDataTests.swift
@@ -39,7 +39,7 @@ struct KeyDataTests {
     }
 
     @Test
-    func random_createsRandomKey() throws {
+    func random_createsRandomKey() {
         var seen = Set<KeyData<32>>()
         for _ in 1 ... 100 {
             let key = KeyData<32>.random()
@@ -49,14 +49,14 @@ struct KeyDataTests {
     }
 
     @Test
-    func repeating_createsRepeatingBytes() throws {
+    func repeating_createsRepeatingBytes() {
         let key = KeyData<32>.repeating(byte: 0x32)
 
         #expect(key.data.map(\.self) == Array(repeating: 0x32, count: 32))
     }
 
     @Test
-    func zero_createsZeroedKey() throws {
+    func zero_createsZeroedKey() {
         let zero = KeyData<32>.zero()
 
         #expect(zero.data.map(\.self) == Array(repeating: 0, count: 32))
@@ -88,12 +88,12 @@ struct KeyDataTests {
 
     struct ByteLength {
         @Test
-        func bytes8() throws {
+        func bytes8() {
             #expect(KeyData<8>.random().data.count == 8)
         }
 
         @Test
-        func bytes32() throws {
+        func bytes32() {
             #expect(KeyData<32>.random().data.count == 32)
         }
     }

--- a/Vault/Tests/FoundationExtensionsTests/LeakTrackingTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/LeakTrackingTests.swift
@@ -2,10 +2,9 @@ import Foundation
 import Testing
 @testable import TestHelpers
 
-@Suite
 struct LeakTrackingTests {
     @Test @LeakTracked
-    func cleanDeallocation_recordsNoIssue() throws {
+    func cleanDeallocation_recordsNoIssue() {
         _ = trackForMemoryLeaks(Probe())
     }
 
@@ -29,13 +28,13 @@ struct LeakTrackingTests {
 
     @Test @LeakTracked
     @MainActor
-    func mainActor_cleanDeallocation_recordsNoIssue() throws {
+    func mainActor_cleanDeallocation_recordsNoIssue() {
         _ = trackForMemoryLeaks(Probe())
     }
 
     @Test @LeakTracked
     @MainActor
-    func mainActor_async_cleanDeallocation_recordsNoIssue() async throws {
+    func mainActor_async_cleanDeallocation_recordsNoIssue() {
         _ = trackForMemoryLeaks(Probe())
     }
 }

--- a/Vault/Tests/FoundationExtensionsTests/MappedErrorTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/MappedErrorTests.swift
@@ -17,7 +17,7 @@ func withMappedError_noErrorReturnsValue() throws {
 }
 
 @Test
-func withMappedError_throwCallsErrorMap() throws {
+func withMappedError_throwCallsErrorMap() {
     var callCount = 0
     #expect(throws: TestError.self, performing: {
         try withMappedError {
@@ -31,7 +31,7 @@ func withMappedError_throwCallsErrorMap() throws {
 }
 
 @Test
-func withCatchingError_returnsNilIfNoError() throws {
+func withCatchingError_returnsNilIfNoError() {
     let result = withCatchingError {
         100
     }
@@ -40,7 +40,7 @@ func withCatchingError_returnsNilIfNoError() throws {
 }
 
 @Test
-func withCatchingError_returnsErrorIfError() throws {
+func withCatchingError_returnsErrorIfError() {
     let result = withCatchingError {
         throw TestError()
     }

--- a/Vault/Tests/FoundationExtensionsTests/PendingValueTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/PendingValueTests.swift
@@ -70,7 +70,7 @@ struct PendingValueTests {
     }
 
     @Test
-    func wait_throwsAlreadyWaitingErrorIfAlreadyWaiting() async throws {
+    func wait_throwsAlreadyWaitingErrorIfAlreadyWaiting() async {
         var task: Task<Void, any Error>?
         await withCheckedContinuation { continutation in
             task = Task.detached(priority: .high) {
@@ -89,7 +89,7 @@ struct PendingValueTests {
     }
 
     @Test
-    func wait_timeoutFulfillsWithError() async throws {
+    func wait_timeoutFulfillsWithError() async {
         await #expect(throws: TimeoutError.self, performing: {
             _ = try await sut.wait(timeout: .nanoseconds(1))
         })
@@ -137,7 +137,7 @@ struct PendingValueTests {
     }
 
     @Test
-    func reject_beforeAwaitResolvesWithInitialError() async throws {
+    func reject_beforeAwaitResolvesWithInitialError() async {
         await sut.reject(error: TestError.testCase)
 
         await #expect(throws: TestError.testCase, performing: {
@@ -146,7 +146,7 @@ struct PendingValueTests {
     }
 
     @Test
-    func reject_resolvesWithMostRecentError() async throws {
+    func reject_resolvesWithMostRecentError() async {
         await sut.reject(error: TestError.testCase)
         await sut.reject(error: TestError.testCase2)
 

--- a/Vault/Tests/FoundationExtensionsTests/Task+RaceTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/Task+RaceTests.swift
@@ -67,7 +67,7 @@ enum TaskRaceTests {
         }
 
         @Test(arguments: [TestTask.t1, .t2, .t3])
-        func errorInAnyTaskPropagatesError(erroringTask: TestTask) async throws {
+        func errorInAnyTaskPropagatesError(erroringTask: TestTask) async {
             let pending1 = Pending.signal()
             let pending2 = Pending.signal()
             let pending3 = Pending.signal()

--- a/Vault/Tests/FoundationExtensionsTests/Task+TimeoutTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/Task+TimeoutTests.swift
@@ -18,7 +18,7 @@ struct TaskTimeoutTests {
     }
 
     @Test
-    func cancelledReturnsCancelledError() async throws {
+    func cancelledReturnsCancelledError() async {
         let parent = Task {
             try await Task.withTimeout(delay: .milliseconds(500)) {
                 try await suspendForever()

--- a/Vault/Tests/ImageToolsTests/ResizeImageTransformerTests.swift
+++ b/Vault/Tests/ImageToolsTests/ResizeImageTransformerTests.swift
@@ -25,7 +25,6 @@ extension ResizeImageTransformerTests {
     private func exampleImage() throws -> UIImage {
         let qr = QRCodeImageRenderer()
         let data = Data(repeating: 0xFF, count: 200)
-        let image = try #require(qr.makeImage(fromData: data))
-        return image
+        return try #require(qr.makeImage(fromData: data))
     }
 }

--- a/Vault/Tests/VaultBackupTests/VaultDecryptorTests.swift
+++ b/Vault/Tests/VaultBackupTests/VaultDecryptorTests.swift
@@ -66,8 +66,7 @@ struct VaultDecryptorTests {
 
 extension VaultDecryptorTests {
     private func makeSUT(key: Data) throws -> VaultDecryptor {
-        let sut = try VaultDecryptor(key: .init(data: key))
-        return sut
+        try VaultDecryptor(key: .init(data: key))
     }
 
     private func anyVaultKey() throws -> Data {

--- a/Vault/Tests/VaultBackupTests/VaultEncryptorTests.swift
+++ b/Vault/Tests/VaultBackupTests/VaultEncryptorTests.swift
@@ -66,8 +66,7 @@ extension VaultEncryptorTests {
         keygenSalt: Data = Data(),
         keygenSignature: String = "my-signature",
     ) -> VaultEncryptor {
-        let sut = VaultEncryptor(key: key, keygenSalt: keygenSalt, keygenSignature: keygenSignature)
-        return sut
+        VaultEncryptor(key: key, keygenSalt: keygenSalt, keygenSignature: keygenSignature)
     }
 
     private func anyVaultKey() -> VaultKey {

--- a/Vault/Tests/VaultBackupTests/VaultExportPDFDocumentRendererTests.swift
+++ b/Vault/Tests/VaultBackupTests/VaultExportPDFDocumentRendererTests.swift
@@ -75,12 +75,11 @@ extension VaultExportPDFDocumentRendererTests {
         file _: StaticString = #filePath,
         line _: UInt = #line,
     ) -> VaultExportPDFDocumentRenderer<PDFDocumentRendererMock> {
-        let sut = VaultExportPDFDocumentRenderer(
+        VaultExportPDFDocumentRenderer(
             renderer: documentRenderer,
             dataShardBuilder: DataShardBuilder(),
             attacher: attacher,
         )
-        return sut
     }
 }
 

--- a/Vault/Tests/VaultCoreTests/Base32/Base32Tests.swift
+++ b/Vault/Tests/VaultCoreTests/Base32/Base32Tests.swift
@@ -172,7 +172,7 @@ struct Base32Tests {
     }
 
     @Test
-    func base32Decode() throws {
+    func base32Decode() {
         let b32 = "AY22KLPRBYJXNH6TRM4I3LPBYA======"
         #expect(throws: Never.self, performing: {
             _ = try b32.base32DecodedData

--- a/Vault/Tests/VaultCoreTests/Clock/IntervalTimerTests.swift
+++ b/Vault/Tests/VaultCoreTests/Clock/IntervalTimerTests.swift
@@ -112,7 +112,7 @@ enum IntervalTimerTests {
         }
 
         @Test
-        func finishTimer_timesOutAfter5SecondsIfThereIsNoWait() async throws {
+        func finishTimer_timesOutAfter5SecondsIfThereIsNoWait() async {
             await #expect(throws: TimeoutError.self, performing: {
                 try await sut.finishTimer(at: 0)
             })
@@ -183,7 +183,7 @@ enum IntervalTimerTests {
         }
 
         @Test
-        func schedule_isolatesWorkToGlobalActor() async throws {
+        func schedule_isolatesWorkToGlobalActor() async {
             @MainActor
             class Thing {
                 var time = 100

--- a/Vault/Tests/VaultCoreTests/OTPCodeRendererTests.swift
+++ b/Vault/Tests/VaultCoreTests/OTPCodeRendererTests.swift
@@ -32,7 +32,7 @@ struct OTPCodeRendererTests {
         (1234, 2, "34"),
         (1234, 3, "234"),
     ])
-    func render_codeTooLongTruncatesToSuffix(code: BigUInt, digits: UInt16, expected: String) throws {
+    func render_codeTooLongTruncatesToSuffix(code: BigUInt, digits: UInt16, expected: String) {
         let sut = OTPCodeRenderer()
         #expect(sut.render(code: code, digits: digits) == expected)
     }

--- a/Vault/Tests/VaultCoreTests/URI/OTPAuthURIDecoderTests.swift
+++ b/Vault/Tests/VaultCoreTests/URI/OTPAuthURIDecoderTests.swift
@@ -133,7 +133,7 @@ struct OTPAuthURIDecoderTests {
         "otpauth://totp/any?algorithm=BAD",
         "otpauth://totp/any?algorithm=%20",
     ])
-    func decodeAlgorithm_throwsForInvalidAlgorithm(uri: String) throws {
+    func decodeAlgorithm_throwsForInvalidAlgorithm(uri: String) {
         #expect(throws: OTPAuthURIDecoder.URIDecodingError.invalidAlgorithm, performing: {
             try sut.decode(uri)
         })
@@ -164,7 +164,7 @@ struct OTPAuthURIDecoderTests {
         "otpauth://totp/any?digits=-10",
         "otpauth://totp/any?digits=-9999",
     ])
-    func decodeDigits_throwsForNegativeNumber(uri: String) throws {
+    func decodeDigits_throwsForNegativeNumber(uri: String) {
         #expect(throws: OTPAuthURIDecoder.URIDecodingError.invalidValue, performing: {
             try sut.decode(uri)
         })
@@ -174,7 +174,7 @@ struct OTPAuthURIDecoderTests {
         "otpauth://totp/any?digits=80000",
         "otpauth://totp/any?digits=99999999999999",
     ])
-    func decodeDigits_throwsForTooLargeNumber(uri: String) throws {
+    func decodeDigits_throwsForTooLargeNumber(uri: String) {
         #expect(throws: OTPAuthURIDecoder.URIDecodingError.invalidValue, performing: {
             try sut.decode(uri)
         })
@@ -213,7 +213,7 @@ struct OTPAuthURIDecoderTests {
         "otpauth://totp/any?secret=ee~~~",
         "otpauth://totp/any?secret=1x%20",
     ])
-    func decodeSecret_invalidBase32ThrowsDecodingError(uri: String) throws {
+    func decodeSecret_invalidBase32ThrowsDecodingError(uri: String) {
         #expect(throws: (any Error).self, performing: {
             try sut.decode(uri)
         })

--- a/Vault/Tests/VaultExportTests/PDFDataBlockDocumentRendererSnapshotTests.swift
+++ b/Vault/Tests/VaultExportTests/PDFDataBlockDocumentRendererSnapshotTests.swift
@@ -409,7 +409,7 @@ private struct OffCenterMarginsDocumentSize: PDFDocumentSize {
 }
 
 private struct StubPDFRendererFactory: PDFRendererFactory {
-    // us letter size for stub
+    /// us letter size for stub
     var size: any PDFDocumentSize = USLetterDocumentSize()
 }
 

--- a/Vault/Tests/VaultExportTests/PDFDataBlockDocumentRendererUnitTests.swift
+++ b/Vault/Tests/VaultExportTests/PDFDataBlockDocumentRendererUnitTests.swift
@@ -25,7 +25,7 @@ struct PDFDataBlockDocumentRendererUnitTests {
     }
 
     @Test
-    func render_makesSingleRendererFromFactory() throws {
+    func render_makesSingleRendererFromFactory() {
         let rendererFactory = makeRendererFactory()
         let sut = makeSUT(rendererFactory: rendererFactory)
 

--- a/Vault/Tests/VaultFeedTests/CodeScanner/BackupImportScanningHandlerTests.swift
+++ b/Vault/Tests/VaultFeedTests/CodeScanner/BackupImportScanningHandlerTests.swift
@@ -30,7 +30,7 @@ struct BackupImportScanningHandlerTests {
     }
 
     @Test
-    func makeSimulatedHandler_returnsExampleVault() throws {
+    func makeSimulatedHandler_returnsExampleVault() {
         let simulated = sut.makeSimulatedHandler()
 
         let result = simulated.decodeSimulated()
@@ -63,7 +63,7 @@ struct BackupImportScanningHandlerTests {
     }
 
     @Test(arguments: [0, 1, 2, 3])
-    func decode_partialShardContinuesScanning(shardNumber: Int) throws {
+    func decode_partialShardContinuesScanning(shardNumber: Int) {
         let result = sut.decode(data: """
         {
             "G":{"ID":10,"N":4,"I":\(shardNumber)},

--- a/Vault/Tests/VaultFeedTests/CodeScanner/CodeScanningManagerTests.swift
+++ b/Vault/Tests/VaultFeedTests/CodeScanner/CodeScanningManagerTests.swift
@@ -4,7 +4,6 @@ import Testing
 import VaultCore
 import VaultFeed
 
-@Suite
 @MainActor
 struct CodeScanningManagerTests {
     @Test
@@ -133,7 +132,7 @@ struct CodeScanningManagerTests {
     }
 
     @Test
-    func scan_unrecoverableErrorSetsStateToDataError() async throws {
+    func scan_unrecoverableErrorSetsStateToDataError() {
         let timer = IntervalTimerMock()
         let handler = CodeScanningHandlerMock()
         handler.decodeHandler = { _ in .endScanning(.unrecoverableError) }
@@ -163,7 +162,7 @@ struct CodeScanningManagerTests {
     }
 
     @Test
-    func scan_scanningStateUnchangedIfShouldIgnore() async throws {
+    func scan_scanningStateUnchangedIfShouldIgnore() {
         let timer = IntervalTimerMock()
         let handler = CodeScanningHandlerMock()
         handler.decodeHandler = { _ in .continueScanning(.ignore) }

--- a/Vault/Tests/VaultFeedTests/CodeScanner/OTPCodeScanningHandlerTests.swift
+++ b/Vault/Tests/VaultFeedTests/CodeScanner/OTPCodeScanningHandlerTests.swift
@@ -17,7 +17,7 @@ struct OTPCodeScanningHandlerTests {
     }
 
     @Test
-    func decode_successCompletesWithExpectedCode() throws {
+    func decode_successCompletesWithExpectedCode() {
         let result = sut.decode(data: "otpauth://totp/issuer?secret=AA&algorithm=SHA256&digits=7&period=32")
 
         switch result {

--- a/Vault/Tests/VaultFeedTests/Encryption/KillphraseKeyStoreImplTests.swift
+++ b/Vault/Tests/VaultFeedTests/Encryption/KillphraseKeyStoreImplTests.swift
@@ -82,8 +82,8 @@ struct KillphraseKeyStoreImplTests {
 }
 
 extension KillphraseKeyStoreImplTests {
-    // Actor-backed recorder for the `@Sendable` store closure to write
-    // into without tripping captured-var concurrency diagnostics.
+    /// Actor-backed recorder for the `@Sendable` store closure to write
+    /// into without tripping captured-var concurrency diagnostics.
     fileprivate actor StoreRecorder {
         private(set) var stored: (data: Data, key: String)?
         func record(data: Data, key: String) {

--- a/Vault/Tests/VaultFeedTests/Encryption/SecureNoteEncryptableTests.swift
+++ b/Vault/Tests/VaultFeedTests/Encryption/SecureNoteEncryptableTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 struct SecureNoteEncryptableTests {
     @Test
-    func init_fromEncryptedContainer() throws {
+    func init_fromEncryptedContainer() {
         let container = SecureNote.EncryptedContainer(
             title: "This is a test",
             contents: "Test contents",

--- a/Vault/Tests/VaultFeedTests/Models/VaultDateFormatterTests.swift
+++ b/Vault/Tests/VaultFeedTests/Models/VaultDateFormatterTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultFeed
 
-@Suite
 struct VaultDateFormatterTests {
     @Test
     func formatForFileName_usesDashesInTime() {

--- a/Vault/Tests/VaultFeedTests/Models/VaultItemTagTests.swift
+++ b/Vault/Tests/VaultFeedTests/Models/VaultItemTagTests.swift
@@ -3,7 +3,6 @@ import FoundationExtensions
 import Testing
 @testable import VaultFeed
 
-@Suite
 struct VaultItemTagTests {
     @Test
     func equal_checksWholeObject() {

--- a/Vault/Tests/VaultFeedTests/Models/VaultItemTests.swift
+++ b/Vault/Tests/VaultFeedTests/Models/VaultItemTests.swift
@@ -5,7 +5,6 @@ import Testing
 import VaultCore
 @testable import VaultFeed
 
-@Suite
 struct VaultItemTests {
     @Test
     func isContentEqual_comparesIDs() {

--- a/Vault/Tests/VaultFeedTests/Presentation/BackupCreatePDFViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/BackupCreatePDFViewModelTests.swift
@@ -5,7 +5,6 @@ import VaultCore
 import VaultKeygen
 @testable import VaultFeed
 
-@Suite
 @MainActor
 struct BackupCreatePDFViewModelTests {
     @Test

--- a/Vault/Tests/VaultFeedTests/Presentation/BackupImportFlowViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/BackupImportFlowViewModelTests.swift
@@ -6,7 +6,6 @@ import VaultBackup
 import VaultKeygen
 @testable import VaultFeed
 
-@Suite
 @MainActor
 struct BackupImportFlowViewModelTests {
     @Test
@@ -42,7 +41,7 @@ struct BackupImportFlowViewModelTests {
     }
 
     @Test
-    func handleImportFromEncryptedVault_failedToDecrypt() async throws {
+    func handleImportFromEncryptedVault_failedToDecrypt() async {
         let encryptedVaultDecoder = EncryptedVaultDecoderMock()
         encryptedVaultDecoder.decryptAndDecodeHandler = { _, _ in
             throw TestError()
@@ -59,7 +58,7 @@ struct BackupImportFlowViewModelTests {
     }
 
     @Test
-    func handleImportFromEncryptedVault_noExistingPasswordPromptsForDifferentPassword() async throws {
+    func handleImportFromEncryptedVault_noExistingPasswordPromptsForDifferentPassword() async {
         let encryptedVaultDecoder = EncryptedVaultDecoderMock()
         encryptedVaultDecoder.decryptAndDecodeHandler = { _, _ in
             anyVaultApplicationPayload()
@@ -77,7 +76,7 @@ struct BackupImportFlowViewModelTests {
     }
 
     @Test
-    func handleImportFromEncryptedVault_wrongDecryptionPasswordPromptsForDifferentPassword() async throws {
+    func handleImportFromEncryptedVault_wrongDecryptionPasswordPromptsForDifferentPassword() async {
         let encryptedVaultDecoder = EncryptedVaultDecoderMock()
         encryptedVaultDecoder.decryptAndDecodeHandler = { _, _ in
             throw EncryptedVaultDecoderError.decryption
@@ -230,7 +229,7 @@ struct BackupImportFlowViewModelTests {
     }
 
     @Test
-    func importPayload_toEmptyVault() async throws {
+    func importPayload_toEmptyVault() async {
         let importer = VaultStoreImporterMock()
         let dataModel = anyVaultDataModel(vaultImporter: importer)
         let sut = makeSUT(importContext: .toEmptyVault, dataModel: dataModel)
@@ -243,7 +242,7 @@ struct BackupImportFlowViewModelTests {
     }
 
     @Test
-    func importPayload_merge() async throws {
+    func importPayload_merge() async {
         let importer = VaultStoreImporterMock()
         let dataModel = anyVaultDataModel(vaultImporter: importer)
         let sut = makeSUT(importContext: .merge, dataModel: dataModel)
@@ -256,7 +255,7 @@ struct BackupImportFlowViewModelTests {
     }
 
     @Test
-    func importPayload_override() async throws {
+    func importPayload_override() async {
         let importer = VaultStoreImporterMock()
         let dataModel = anyVaultDataModel(vaultImporter: importer)
         let sut = makeSUT(importContext: .override, dataModel: dataModel)

--- a/Vault/Tests/VaultFeedTests/Presentation/BackupKeyChangeViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/BackupKeyChangeViewModelTests.swift
@@ -6,7 +6,6 @@ import Testing
 import VaultKeygen
 @testable import VaultFeed
 
-@Suite
 @MainActor
 struct BackupKeyChangeViewModelTests {
     @Test
@@ -152,7 +151,9 @@ extension BackupKeyChangeViewModelTests {
     }
 
     private struct KeyDeriverErroring: KeyDeriver {
-        var uniqueAlgorithmIdentifier: String { "err" }
+        var uniqueAlgorithmIdentifier: String {
+            "err"
+        }
 
         func key(password _: Data, salt _: Data) throws -> KeyData<32> {
             struct Err: Error {}

--- a/Vault/Tests/VaultFeedTests/Presentation/BackupKeyDecryptorViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/BackupKeyDecryptorViewModelTests.swift
@@ -9,7 +9,7 @@ import VaultKeygen
 @MainActor
 struct BackupKeyDecryptorViewModelTests {
     @Test @LeakTracked
-    func init_setsInitialState() throws {
+    func init_setsInitialState() {
         let sut = makeSUT()
 
         #expect(sut.enteredPassword == "")
@@ -17,7 +17,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func canAttemptDecryption_falseIfPasswordEmpty() async throws {
+    func canAttemptDecryption_falseIfPasswordEmpty() {
         let sut = makeSUT()
         sut.enteredPassword = ""
 
@@ -25,7 +25,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func canAttemptDecryption_trueIfPasswordNotEmpty() async throws {
+    func canAttemptDecryption_trueIfPasswordNotEmpty() {
         let sut = makeSUT()
         sut.enteredPassword = "a"
 
@@ -33,7 +33,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func attemptDecryption_validPasswordGeneratesConsistentlyWithSalt() async throws {
+    func attemptDecryption_validPasswordGeneratesConsistentlyWithSalt() async {
         let vaultApplicationPayload = VaultApplicationPayload(userDescription: "my stuff", items: [], tags: [])
         let decoder = EncryptedVaultDecoderMock()
         // returned payload implies successful decryption
@@ -64,7 +64,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func generateKey_emptyPasswordGeneratesError() async throws {
+    func generateKey_emptyPasswordGeneratesError() async {
         let decoder = EncryptedVaultDecoderMock()
         decoder.verifyCanDecryptHandler = { _, _ in throw TestError() }
         let sut = makeSUT(encryptedVaultDecoder: decoder)
@@ -76,7 +76,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func generateKey_keyDeriverErrorGeneratesError() async throws {
+    func generateKey_keyDeriverErrorGeneratesError() async {
         let sut = makeSUT(keyDeriverFactory: .failing)
         sut.enteredPassword = "hello"
 

--- a/Vault/Tests/VaultFeedTests/Presentation/DetailEditStateTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/DetailEditStateTests.swift
@@ -76,7 +76,7 @@ struct DetailEditStateTests {
     }
 
     @Test
-    func saveChanges_failureDoesNotChangeEditMode() async throws {
+    func saveChanges_failureDoesNotChangeEditMode() async {
         let sut = makeSUT()
         sut.startEditing()
 
@@ -179,7 +179,7 @@ struct DetailEditStateTests {
     }
 
     @Test
-    func deleteItem_failureDoesNotChangeEditMode() async throws {
+    func deleteItem_failureDoesNotChangeEditMode() async {
         let sut = makeSUT()
         sut.startEditing()
 
@@ -221,7 +221,7 @@ struct DetailEditStateTests {
     }
 
     @Test
-    func exitCurrentModeClearingDirtyState_clearsDirtyStateInEditMode() async {
+    func exitCurrentModeClearingDirtyState_clearsDirtyStateInEditMode() {
         let sut = makeSUT()
         sut.startEditing()
 

--- a/Vault/Tests/VaultFeedTests/Presentation/DeviceTransferExportViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/DeviceTransferExportViewModelTests.swift
@@ -6,7 +6,6 @@ import VaultCore
 import VaultKeygen
 @testable import VaultFeed
 
-@Suite
 @MainActor
 struct DeviceTransferExportViewModelTests {
     @Test

--- a/Vault/Tests/VaultFeedTests/Presentation/EncryptedItemDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/EncryptedItemDetailViewModelTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultFeed
 
-@Suite
 @MainActor
 final class EncryptedItemDetailViewModelTests {
     @Test

--- a/Vault/Tests/VaultFeedTests/Presentation/FieldValidatedTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/FieldValidatedTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultFeed
 
-@Suite
 struct FieldValidatedTests {
     @Test
     func wrappedValue_setsBasedOnValue() {

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/DetailEditingModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/DetailEditingModelTests.swift
@@ -11,7 +11,7 @@ struct DetailEditingModelTests {
     }
 
     @Test
-    func isDirtyResetsOncePersisted() async throws {
+    func isDirtyResetsOncePersisted() {
         var sut = makeSUT(detail: .init(value: "hello"))
 
         sut.detail.value = "next"
@@ -21,7 +21,7 @@ struct DetailEditingModelTests {
     }
 
     @Test
-    func isDirtyIsInitiallyDirtyAlwaysMakesDirty() throws {
+    func isDirtyIsInitiallyDirtyAlwaysMakesDirty() {
         var sut = makeSUT(detail: .init(value: "hello"), isInitiallyDirty: true)
 
         #expect(sut.isDirty)
@@ -34,7 +34,7 @@ struct DetailEditingModelTests {
     }
 
     @Test
-    func isDirtyIsInitiallyDirtyPersistEnablesNormalDirtyState() throws {
+    func isDirtyIsInitiallyDirtyPersistEnablesNormalDirtyState() {
         var sut = makeSUT(detail: .init(value: "hello"), isInitiallyDirty: true)
 
         #expect(sut.isDirty)
@@ -58,6 +58,8 @@ extension DetailEditingModelTests {
 
     struct EditableStateMock: EditableState {
         var value: String
-        var isValid: Bool { true }
+        var isValid: Bool {
+            true
+        }
     }
 }

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/HOTPCodePublisherTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/HOTPCodePublisherTests.swift
@@ -4,7 +4,6 @@ import Foundation
 import Testing
 @testable import VaultFeed
 
-@Suite
 @MainActor
 struct HOTPCodePublisherTests {
     @Test
@@ -52,8 +51,7 @@ struct HOTPCodePublisherTests {
     // MARK: - Helpers
 
     private func makeSUT(digits: UInt16) -> HOTPCodePublisher {
-        let sut = HOTPCodePublisher(hotpGenerator: fixedGenerator(digits: digits))
-        return sut
+        HOTPCodePublisher(hotpGenerator: fixedGenerator(digits: digits))
     }
 
     private func fixedGenerator(digits: UInt16) -> HOTPGenerator {

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailEditsTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailEditsTests.swift
@@ -4,7 +4,6 @@ import Testing
 import VaultCore
 @testable import VaultFeed
 
-@Suite
 struct OTPCodeDetailEditsTests {
     @Test
     func initHydratedFromCode_assignsTOTPCodeType() {
@@ -118,7 +117,7 @@ struct OTPCodeDetailEditsTests {
     }
 
     @Test
-    func isValid_validSecretIsValid() throws {
+    func isValid_validSecretIsValid() {
         let code = anyOTPAuthCode(secret: makeExampleSecret())
 
         let sut = OTPCodeDetailEdits(
@@ -139,7 +138,7 @@ struct OTPCodeDetailEditsTests {
     }
 
     @Test
-    func isValid_invalidForEmptySecret() throws {
+    func isValid_invalidForEmptySecret() {
         var sut = OTPCodeDetailEdits.new()
         sut.secretBase32String = ""
 
@@ -147,7 +146,7 @@ struct OTPCodeDetailEditsTests {
     }
 
     @Test
-    func isValid_invalidForEmptyIssuer() throws {
+    func isValid_invalidForEmptyIssuer() {
         var sut = OTPCodeDetailEdits.new()
         sut.issuerTitle = ""
 
@@ -155,7 +154,7 @@ struct OTPCodeDetailEditsTests {
     }
 
     @Test
-    func isValid_invalidSecretIsInvalid() throws {
+    func isValid_invalidSecretIsInvalid() {
         var sut = OTPCodeDetailEdits.new()
         sut.secretBase32String = "A" // this is invalid
 
@@ -163,7 +162,7 @@ struct OTPCodeDetailEditsTests {
     }
 
     @Test
-    func isValid_invalidForEmptyPassphrase() throws {
+    func isValid_invalidForEmptyPassphrase() {
         var sut = OTPCodeDetailEdits.new()
         sut.searchPassphrase = ""
         sut.viewConfig = .requiresSearchPassphrase
@@ -172,7 +171,7 @@ struct OTPCodeDetailEditsTests {
     }
 
     @Test
-    func isValid_validForNonEmptyPassphrase() throws {
+    func isValid_validForNonEmptyPassphrase() {
         var sut = OTPCodeDetailEdits.new()
         sut.secretBase32String = "AA"
         sut.issuerTitle = "any"

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeDetailViewModelTests.swift
@@ -5,7 +5,6 @@ import Testing
 import VaultCore
 import VaultFeed
 
-@Suite
 @MainActor
 struct OTPCodeDetailViewModelTests {
     @Test
@@ -107,7 +106,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func startEditing_setsEditModeTrue() async throws {
+    func startEditing_setsEditModeTrue() {
         let sut = makeSUTEditing()
 
         sut.startEditing()
@@ -123,7 +122,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_creatingUpdatesEditor() async throws {
+    func saveChanges_creatingUpdatesEditor() async {
         let editor = OTPCodeDetailEditorMock()
         let sut = makeSUTCreating(editor: editor)
 
@@ -138,7 +137,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_creatingDoesNotPersistEditingModelWhenSuccessful() async throws {
+    func saveChanges_creatingDoesNotPersistEditingModelWhenSuccessful() async {
         let sut = makeSUTCreating()
         makeDirty(sut: sut)
 
@@ -170,7 +169,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_creatingSetsSavingToFalseAfterSaveError() async throws {
+    func saveChanges_creatingSetsSavingToFalseAfterSaveError() async {
         let editor = OTPCodeDetailEditorMock()
         editor.createCodeHandler = { _ in
             throw TestError()
@@ -183,7 +182,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_editingPersistsEditingModelIfSuccessful() async throws {
+    func saveChanges_editingPersistsEditingModelIfSuccessful() async {
         let sut = makeSUTEditing()
         makeDirty(sut: sut)
 
@@ -193,7 +192,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_editingSetsSavingToFalseAfterSaveError() async throws {
+    func saveChanges_editingSetsSavingToFalseAfterSaveError() async {
         let editor = OTPCodeDetailEditorMock()
         editor.updateCodeHandler = { _, _, _ in
             throw TestError()
@@ -206,7 +205,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_editingDoesNotPersistEditingModelIfSaveFailed() async throws {
+    func saveChanges_editingDoesNotPersistEditingModelIfSaveFailed() async {
         let editor = OTPCodeDetailEditorMock()
         editor.updateCodeHandler = { _, _, _ in
             throw TestError()
@@ -233,7 +232,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func deleteCode_hasNoActionIfCreatingCode() async throws {
+    func deleteCode_hasNoActionIfCreatingCode() async {
         let editor = OTPCodeDetailEditorMock()
         let sut = makeSUTCreating(editor: editor)
 
@@ -243,7 +242,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func deleteCode_editingIsSavingSetsBackToFalseAfterSuccessfulDelete() async throws {
+    func deleteCode_editingIsSavingSetsBackToFalseAfterSuccessfulDelete() async {
         let sut = makeSUTEditing()
 
         await sut.deleteCode()
@@ -274,7 +273,7 @@ struct OTPCodeDetailViewModelTests {
     }
 
     @Test
-    func done_restoresInitialEditingStateIfInEditMode() async throws {
+    func done_restoresInitialEditingStateIfInEditMode() {
         let sut = makeSUT()
         sut.startEditing()
         makeDirty(sut: sut)
@@ -459,12 +458,11 @@ extension OTPCodeDetailViewModelTests {
         ),
         allTags _: [VaultItemTag] = [],
     ) -> OTPCodeDetailViewModel {
-        let sut = OTPCodeDetailViewModel(
+        OTPCodeDetailViewModel(
             mode: .creating(initialCode: initialCode),
             dataModel: dataModel,
             editor: editor,
         )
-        return sut
     }
 
     @MainActor
@@ -487,12 +485,11 @@ extension OTPCodeDetailViewModelTests {
             backupEventLogger: BackupEventLoggerMock(),
         ),
     ) -> OTPCodeDetailViewModel {
-        let sut = OTPCodeDetailViewModel(
+        OTPCodeDetailViewModel(
             mode: .editing(code: code, metadata: metadata),
             dataModel: dataModel,
             editor: editor,
         )
-        return sut
     }
 
     @MainActor
@@ -515,12 +512,11 @@ extension OTPCodeDetailViewModelTests {
             backupEventLogger: BackupEventLoggerMock(),
         ),
     ) -> OTPCodeDetailViewModel {
-        let sut = OTPCodeDetailViewModel(
+        OTPCodeDetailViewModel(
             mode: .editing(code: code, metadata: metadata),
             dataModel: dataModel,
             editor: editor,
         )
-        return sut
     }
 
     @MainActor
@@ -532,8 +528,7 @@ extension OTPCodeDetailViewModelTests {
 
 extension OTPCodeDetailEditorMock {
     static func defaultMock() -> OTPCodeDetailEditorMock {
-        let s = OTPCodeDetailEditorMock()
-        return s
+        OTPCodeDetailEditorMock()
     }
 
     func assertNoOperations() {

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeIncrementerViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeIncrementerViewModelTests.swift
@@ -8,7 +8,7 @@ import VaultFeed
 @MainActor
 struct OTPCodeIncrementerViewModelTests {
     @Test @LeakTracked
-    func isButtonEnabled_isInitiallyTrue() throws {
+    func isButtonEnabled_isInitiallyTrue() {
         let sut = makeSUT()
 
         #expect(sut.isButtonEnabled)

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodePreviewViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodePreviewViewModelTests.swift
@@ -5,7 +5,6 @@ import Testing
 import VaultCore
 import VaultFeed
 
-@Suite
 @MainActor
 struct OTPCodePreviewViewModelTests {
     @Test

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeTimerAnimationStateTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeTimerAnimationStateTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 import VaultFeed
 
-@Suite
 struct OTPCodeTimerAnimationStateTests {
     @Test
     func initialFraction_freezeIsFraction() {

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeTimerStateTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeTimerStateTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 import VaultFeed
 
-@Suite
 struct OTPCodeTimerStateTests {
     @Test
     func init_startTimeAndEndTimeIsValues() {

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeTimerUpdaterImplTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeTimerUpdaterImplTests.swift
@@ -76,7 +76,6 @@ struct OTPCodeTimerUpdaterImplTests {
         timer: IntervalTimerMock = IntervalTimerMock(),
         period: UInt64,
     ) -> OTPCodeTimerUpdaterImpl {
-        let sut = OTPCodeTimerUpdaterImpl(timer: timer, period: period, clock: clock)
-        return sut
+        OTPCodeTimerUpdaterImpl(timer: timer, period: period, clock: clock)
     }
 }

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/TOTPCodePublisherTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/TOTPCodePublisherTests.swift
@@ -6,7 +6,6 @@ import Testing
 import VaultCore
 @testable import VaultFeed
 
-@Suite
 @MainActor
 struct TOTPCodePublisherTests {
     @Test

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/TOTPPreviewViewRepositoryImplTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/TOTPPreviewViewRepositoryImplTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultFeed
 
-@Suite
 @MainActor
 struct TOTPPreviewViewRepositoryImplTests {
     @Test
@@ -141,7 +140,7 @@ struct TOTPPreviewViewRepositoryImplTests {
     }
 
     @Test
-    func obfuscateForPrivacy_obfuscatesViewModelsForPrivacy() async {
+    func obfuscateForPrivacy_obfuscatesViewModelsForPrivacy() {
         let sut = makeSUT()
         let viewModel = sut.previewViewModel(metadata: anyVaultItemMetadata(), code: anyTOTPCode())
         viewModel.update(.visible("123456"))

--- a/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailEditsTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailEditsTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultFeed
 
-@Suite
 struct SecureNoteDetailEditsTests {
     @Test
     func isValid_validForTitleWithContents() {

--- a/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNoteDetailViewModelTests.swift
@@ -4,7 +4,6 @@ import Testing
 import VaultCore
 import VaultFeed
 
-@Suite
 @MainActor
 struct SecureNoteDetailViewModelTests {
     @Test
@@ -84,7 +83,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_creatingUpdatesEditor() async throws {
+    func saveChanges_creatingUpdatesEditor() async {
         let editor = SecureNoteDetailEditorMock()
         let sut = makeSUTCreating(editor: editor)
 
@@ -98,7 +97,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_creatingDoesNotPersistEditingModelWhenSuccessful() async throws {
+    func saveChanges_creatingDoesNotPersistEditingModelWhenSuccessful() async {
         let sut = makeSUTCreating()
         makeDirty(sut: sut)
 
@@ -130,7 +129,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_creatingSetsSavingToFalseAfterSaveError() async throws {
+    func saveChanges_creatingSetsSavingToFalseAfterSaveError() async {
         let editor = SecureNoteDetailEditorMock()
         editor.createNoteHandler = { _ in
             throw TestError()
@@ -143,7 +142,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_updatesEditor() async throws {
+    func saveChanges_updatesEditor() async {
         let editor = SecureNoteDetailEditorMock()
         let sut = makeSUTEditing(editor: editor)
 
@@ -157,7 +156,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_persistsEditingModelIfSuccessful() async throws {
+    func saveChanges_persistsEditingModelIfSuccessful() async {
         let sut = makeSUTEditing()
         makeDirty(sut: sut)
 
@@ -167,7 +166,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_setsSavingToFalseAfterSaveError() async throws {
+    func saveChanges_setsSavingToFalseAfterSaveError() async {
         let editor = SecureNoteDetailEditorMock()
         editor.updateNoteHandler = { _, _, _ in
             throw TestError()
@@ -180,7 +179,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func saveChanges_doesNotPersistEditingModelIfSaveFailed() async throws {
+    func saveChanges_doesNotPersistEditingModelIfSaveFailed() async {
         let editor = SecureNoteDetailEditorMock()
         editor.updateNoteHandler = { _, _, _ in
             throw TestError()
@@ -207,7 +206,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func deleteNote_hasNoActionIfCreatingNote() async throws {
+    func deleteNote_hasNoActionIfCreatingNote() async {
         let editor = SecureNoteDetailEditorMock()
         let sut = makeSUTCreating(editor: editor)
 
@@ -217,7 +216,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func deleteNote_isSavingSetsBackToFalseAfterSuccessfulDelete() async throws {
+    func deleteNote_isSavingSetsBackToFalseAfterSuccessfulDelete() async {
         let sut = makeSUTEditing()
 
         await sut.deleteNote()
@@ -248,7 +247,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func done_restoresInitialEditingStateIfInEditMode() async throws {
+    func done_restoresInitialEditingStateIfInEditMode() {
         let sut = makeSUTEditing()
         sut.startEditing()
         makeDirty(sut: sut)
@@ -378,7 +377,7 @@ struct SecureNoteDetailViewModelTests {
     }
 
     @Test
-    func delete_callsDeleteWrapper() async throws {
+    func delete_callsDeleteWrapper() async {
         let editor = SecureNoteDetailEditorMock()
         let sut = makeSUTEditing(editor: editor)
 

--- a/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNotePreviewViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/SecureNote/SecureNotePreviewViewModelTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 import VaultFeed
 
-@Suite
 struct SecureNotePreviewViewModelTests {
     @Test
     func visibleTitle_isPlaceholderEmptyTitleIfTitleEmpty() {

--- a/Vault/Tests/VaultFeedTests/Presentation/VaultDataModelEditorAdapterTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/VaultDataModelEditorAdapterTests.swift
@@ -6,7 +6,6 @@ import Testing
 import VaultCore
 import VaultFeed
 
-@Suite
 @MainActor
 struct VaultDataModelEditorAdapterTests {
     @Test

--- a/Vault/Tests/VaultFeedTests/Presentation/VaultItemWidgetEligibilityTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/VaultItemWidgetEligibilityTests.swift
@@ -4,7 +4,6 @@ import Testing
 import VaultCore
 @testable import VaultFeed
 
-@Suite
 struct VaultItemWidgetEligibilityTests {
     @Test
     func eligible_whenAllConditionsHold() {

--- a/Vault/Tests/VaultFeedTests/Presentation/VaultTagDetailViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/VaultTagDetailViewModelTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultFeed
 
-@Suite
 @MainActor
 struct VaultTagDetailViewModelTests {
     @Test

--- a/Vault/Tests/VaultFeedTests/Storage/AutoBackupProviderCoverageTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/AutoBackupProviderCoverageTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct AutoBackupProviderCoverageTests {
     @Test
-    func iCloudDriveProvider_unconfiguredStateIsAvailableForSetup() async throws {
+    func iCloudDriveProvider_unconfiguredStateIsAvailableForSetup() async {
         let sut = iCloudDriveProvider()
 
         #expect(sut.id == iCloudDriveProvider.providerID)

--- a/Vault/Tests/VaultFeedTests/Storage/AutoBackupServiceImplTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/AutoBackupServiceImplTests.swift
@@ -449,7 +449,7 @@ extension AutoBackupServiceImplTests {
 
 // MARK: - BackupStorageProviderStub
 
-// All access is from @MainActor test methods, so MainActor isolation is sufficient for Sendable.
+/// All access is from @MainActor test methods, so MainActor isolation is sufficient for Sendable.
 @MainActor
 final class BackupStorageProviderStub: BackupStorageProvider, Sendable {
     let id: String
@@ -462,11 +462,21 @@ final class BackupStorageProviderStub: BackupStorageProvider, Sendable {
     private let backups: [BackupFileInfo]
     private let listBackupsError: (any Error)?
 
-    var isConfigured: Bool { _isConfigured }
-    var isAvailable: Bool { _isAvailable }
+    var isConfigured: Bool {
+        _isConfigured
+    }
 
-    var configurationSummary: String? { _isConfigured ? "Test folder" : nil }
-    var configurationData: Data? { _configurationData }
+    var isAvailable: Bool {
+        _isAvailable
+    }
+
+    var configurationSummary: String? {
+        _isConfigured ? "Test folder" : nil
+    }
+
+    var configurationData: Data? {
+        _configurationData
+    }
 
     private(set) var writeCallCount = 0
     private(set) var writtenData: [(data: Data, filename: String)] = []

--- a/Vault/Tests/VaultFeedTests/Storage/KillphraseRehashServiceTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/KillphraseRehashServiceTests.swift
@@ -87,11 +87,11 @@ struct KillphraseRehashServiceTests {
 }
 
 extension KillphraseRehashServiceTests {
-    // Actor-backed recorder so the `@Sendable` writer closure can
-    // collect invocations and consult the failing-id set without
-    // resorting to `@unchecked Sendable`.
+    /// Actor-backed recorder so the `@Sendable` writer closure can
+    /// collect invocations and consult the failing-id set without
+    /// resorting to `@unchecked Sendable`.
     fileprivate actor WriterRecorder {
-        struct Call: Sendable {
+        struct Call {
             let itemID: UUID
             let digest: KillphraseDigest
         }

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreFactoryTests.swift
@@ -3,7 +3,6 @@ import SwiftData
 import Testing
 @testable import VaultFeed
 
-@Suite
 struct PersistedLocalVaultStoreFactoryTests {
     @Test
     func makeVaultStore_createsEmptyStoreWhenNoExistingStoreExists() async throws {
@@ -323,7 +322,7 @@ struct PersistedLocalVaultStoreFactoryTests {
     }
 }
 
-enum StoreFile: Sendable {
+enum StoreFile {
     case primary
     case wal
     case shm
@@ -331,7 +330,7 @@ enum StoreFile: Sendable {
     case pendingSearchPassphrase
 }
 
-struct ActiveFileScenario: Sendable, CustomStringConvertible {
+struct ActiveFileScenario: CustomStringConvertible {
     let description: String
     let files: [StoreFile]
 
@@ -355,13 +354,13 @@ struct ActiveFileScenario: Sendable, CustomStringConvertible {
     ]
 }
 
-struct ArchiveNameScenario: Sendable {
+struct ArchiveNameScenario {
     let existingDirectories: [String]
     let expectedName: String
 }
 
-struct FatalMessageScenario: Sendable, CustomStringConvertible {
-    enum Failure: Sendable {
+struct FatalMessageScenario: CustomStringConvertible {
+    enum Failure {
         case noActiveFiles
         case createDirectory
         case retryOpen
@@ -401,7 +400,7 @@ struct FatalMessageScenario: Sendable, CustomStringConvertible {
     ]
 }
 
-struct DisappearingFileScenario: Sendable, CustomStringConvertible {
+struct DisappearingFileScenario: CustomStringConvertible {
     let description: String
     let existingFiles: [StoreFile]
     let disappearingFile: StoreFile
@@ -436,7 +435,7 @@ struct DisappearingFileScenario: Sendable, CustomStringConvertible {
     ]
 }
 
-struct LiveMoveFailureScenario: Sendable, CustomStringConvertible {
+struct LiveMoveFailureScenario: CustomStringConvertible {
     let description: String
     let existingFiles: [StoreFile]
     let failingFile: StoreFile
@@ -464,7 +463,7 @@ private enum StoreConnectionErrorCase {
     case unableToConnectAfterRecovery
 }
 
-private enum FactoryTestError: Error, Sendable {
+private enum FactoryTestError: Error {
     case initialOpen
     case retryOpen
     case createDirectory
@@ -473,7 +472,7 @@ private enum FactoryTestError: Error, Sendable {
 }
 
 final class ScriptedStoreOpener: PersistedLocalVaultStoreOpening {
-    enum Result: Sendable {
+    enum Result {
         case success
         case failure(any Error & Sendable)
     }

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedLocalVaultStoreTests.swift
@@ -6,7 +6,6 @@ import Testing
 import VaultCore
 @testable import VaultFeed
 
-@Suite
 final class PersistedLocalVaultStoreTests {
     private var sut: PersistedLocalVaultStore
 

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemDecoderTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemDecoderTests.swift
@@ -6,7 +6,6 @@ import Testing
 import VaultCore
 @testable import VaultFeed
 
-@Suite
 struct PersistedVaultItemDecoderTests {
     private let context: ModelContext
 

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemEncoderTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedVaultItemEncoderTests.swift
@@ -6,7 +6,6 @@ import Testing
 import VaultCore
 @testable import VaultFeed
 
-@Suite
 struct PersistedVaultItemEncoderTests {
     private let context: ModelContext
 

--- a/Vault/Tests/VaultFeedTests/Storage/PersistedVaultTagEncoderTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/PersistedVaultTagEncoderTests.swift
@@ -18,7 +18,7 @@ final class PersistedVaultTagEncoderTests {
 
 extension PersistedVaultTagEncoderTests {
     @Test
-    func encode_newItemCreatedUUID() throws {
+    func encode_newItemCreatedUUID() {
         let sut = makeSUT()
 
         var seenIds = Set<UUID>()
@@ -31,7 +31,7 @@ extension PersistedVaultTagEncoderTests {
     }
 
     @Test
-    func encode_name() throws {
+    func encode_name() {
         let name = "my tag name"
         let sut = makeSUT()
         let item = makeWritableVaultItemTag(name: name)
@@ -42,7 +42,7 @@ extension PersistedVaultTagEncoderTests {
     }
 
     @Test
-    func encode_colorWithValues() throws {
+    func encode_colorWithValues() {
         let sut = makeSUT()
         let color = VaultItemColor(red: 0.5, green: 0.6, blue: 0.7)
         let item = makeWritableVaultItemTag(color: color)
@@ -55,7 +55,7 @@ extension PersistedVaultTagEncoderTests {
     }
 
     @Test
-    func encode_iconName() throws {
+    func encode_iconName() {
         let name = "my icon name"
         let sut = makeSUT()
         let item = makeWritableVaultItemTag(iconName: name)

--- a/Vault/Tests/VaultFeedTests/Storage/SearchPassphraseRehashServiceTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/SearchPassphraseRehashServiceTests.swift
@@ -89,7 +89,7 @@ struct SearchPassphraseRehashServiceTests {
 
 extension SearchPassphraseRehashServiceTests {
     fileprivate actor WriterRecorder {
-        struct Call: Sendable {
+        struct Call {
             let itemID: UUID
             let digest: SearchPassphraseDigest
         }

--- a/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Storage/VaultDataModelTests.swift
@@ -5,7 +5,6 @@ import Testing
 import VaultKeygen
 @testable import VaultFeed
 
-@Suite
 @MainActor
 final class VaultDataModelTests {
     @Test
@@ -136,7 +135,7 @@ final class VaultDataModelTests {
     }
 
     @Test
-    func loadKillphraseDigester_isNoopWhenAlreadyLoaded() async throws {
+    func loadKillphraseDigester_isNoopWhenAlreadyLoaded() async {
         let keyStore = KillphraseKeyStoreMock()
         keyStore.loadOrCreateHandler = {
             try KeyData<32>(data: Data(repeating: 1, count: 32))
@@ -163,7 +162,7 @@ final class VaultDataModelTests {
     }
 
     @Test
-    func loadSearchPassphraseDigester_isNoopWhenAlreadyLoaded() async throws {
+    func loadSearchPassphraseDigester_isNoopWhenAlreadyLoaded() async {
         let keyStore = SearchPassphraseKeyStoreMock()
         keyStore.loadOrCreateHandler = {
             try KeyData<32>(data: Data(repeating: 2, count: 32))
@@ -347,7 +346,7 @@ final class VaultDataModelTests {
     }
 
     @Test
-    func reloadItems_deletesKillphraseItemsBeforeReturningResults() async throws {
+    func reloadItems_deletesKillphraseItemsBeforeReturningResults() async {
         let store = VaultStoreStub()
         let killphraseDeleter = VaultStoreKillphraseDeleterMock()
         let keyStore = KillphraseKeyStoreMock()
@@ -384,7 +383,7 @@ final class VaultDataModelTests {
     }
 
     @Test
-    func reloadItems_syncsAutofillAndNotifiesWhenKillphraseDeletesItems() async throws {
+    func reloadItems_syncsAutofillAndNotifiesWhenKillphraseDeletesItems() async {
         let store = VaultStoreStub()
         let killphraseDeleter = VaultStoreKillphraseDeleterMock()
         let vaultOtpAutofillStore = VaultOTPAutofillStoreMock()
@@ -554,7 +553,7 @@ final class VaultDataModelTests {
     }
 
     @Test
-    func loadBackupPassword_setsFetchedFromStore() async throws {
+    func loadBackupPassword_setsFetchedFromStore() async {
         let store = BackupPasswordStoreMock()
         let password = DerivedEncryptionKey(key: .zero(), salt: Data(), keyDervier: .testing)
         store.fetchPasswordHandler = { password }
@@ -567,7 +566,7 @@ final class VaultDataModelTests {
     }
 
     @Test
-    func loadBackupPassword_setsNotCreatedIfNotInStore() async throws {
+    func loadBackupPassword_setsNotCreatedIfNotInStore() async {
         let store = BackupPasswordStoreMock()
         store.fetchPasswordHandler = { nil }
         let sut = makeSUT(backupPasswordStore: store)
@@ -579,7 +578,7 @@ final class VaultDataModelTests {
     }
 
     @Test
-    func loadBackupPassword_setsErrorIfStoreError() async throws {
+    func loadBackupPassword_setsErrorIfStoreError() async {
         let store = BackupPasswordStoreMock()
         store.fetchPasswordHandler = { throw TestError() }
         let sut = makeSUT(backupPasswordStore: store)
@@ -630,7 +629,7 @@ final class VaultDataModelTests {
     }
 
     @Test
-    func backupPassword_notFetched() async {
+    func backupPassword_notFetched() {
         let store = BackupPasswordStoreMock()
         let sut = makeSUT(backupPasswordStore: store)
 

--- a/Vault/Tests/VaultSettingsTests/LocalSettingsTests.swift
+++ b/Vault/Tests/VaultSettingsTests/LocalSettingsTests.swift
@@ -29,8 +29,7 @@ struct LocalSettingsTests {
 
 extension LocalSettingsTests {
     private func makeSUT(defaults: Defaults) throws -> LocalSettings {
-        let settings = LocalSettings(defaults: defaults)
-        return settings
+        LocalSettings(defaults: defaults)
     }
 }
 

--- a/Vault/Tests/VaultiOSTests/BackupKeyChangeViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/BackupKeyChangeViewSnapshotTests.swift
@@ -6,11 +6,10 @@ import VaultSettings
 @testable import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class BackupKeyChangeViewSnapshotTests {
     @Test
-    func layout() async {
+    func layout() {
         let viewModel = BackupKeyChangeViewModel(
             dataModel: anyVaultDataModel(),
             authenticationService: DeviceAuthenticationService(policy: DeviceAuthenticationPolicyAlwaysAllow()),
@@ -22,7 +21,7 @@ final class BackupKeyChangeViewSnapshotTests {
     }
 
     @Test
-    func layoutAuthenticated() async {
+    func layoutAuthenticated() {
         let viewModel = BackupKeyChangeViewModel(
             dataModel: anyVaultDataModel(),
             authenticationService: DeviceAuthenticationService(policy: DeviceAuthenticationPolicyAlwaysAllow()),

--- a/Vault/Tests/VaultiOSTests/BackupViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/BackupViewSnapshotTests.swift
@@ -8,7 +8,7 @@ import VaultFeed
 @MainActor
 struct BackupViewSnapshotTests {
     @Test
-    func backupCreate_passwordNotFetched() async throws {
+    func backupCreate_passwordNotFetched() {
         let sut = makeBackupCreateSUT(dataModel: anyVaultDataModel())
             .framedForTest()
 

--- a/Vault/Tests/VaultiOSTests/EncryptedItemPreviewViewGeneratorTests.swift
+++ b/Vault/Tests/VaultiOSTests/EncryptedItemPreviewViewGeneratorTests.swift
@@ -30,7 +30,7 @@ struct EncryptedItemPreviewViewGeneratorTests {
     }
 
     @Test
-    func makeVaultPreviewView_propagatesPreviewMode() throws {
+    func makeVaultPreviewView_propagatesPreviewMode() {
         let factory = EncryptedItemPreviewViewFactoryMock()
         var capturedPreviewMode: NotePreviewMode?
         factory.makeEncryptedItemViewHandler = { viewModel, _ in

--- a/Vault/Tests/VaultiOSTests/GenericVaultItemPreviewViewGeneratorTests.swift
+++ b/Vault/Tests/VaultiOSTests/GenericVaultItemPreviewViewGeneratorTests.swift
@@ -7,7 +7,6 @@ import VaultCore
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class GenericVaultItemPreviewViewGeneratorTests {
     @Test
@@ -25,7 +24,7 @@ final class GenericVaultItemPreviewViewGeneratorTests {
     }
 
     @Test
-    func makeVaultPreviewView_makesTOTPViewForTOTP() throws {
+    func makeVaultPreviewView_makesTOTPViewForTOTP() {
         let totp = TOTPGeneratorMock()
         let hotp = HOTPGeneratorMock()
         let note = SecureNoteGeneratorMock()
@@ -39,7 +38,7 @@ final class GenericVaultItemPreviewViewGeneratorTests {
     }
 
     @Test
-    func makeVaultPreviewView_makesHOTPViewForHOTP() throws {
+    func makeVaultPreviewView_makesHOTPViewForHOTP() {
         let totp = TOTPGeneratorMock()
         let hotp = HOTPGeneratorMock()
         let note = SecureNoteGeneratorMock()
@@ -53,7 +52,7 @@ final class GenericVaultItemPreviewViewGeneratorTests {
     }
 
     @Test
-    func makeVaultPreviewView_makesSecureNoteView() throws {
+    func makeVaultPreviewView_makesSecureNoteView() {
         let totp = TOTPGeneratorMock()
         let hotp = HOTPGeneratorMock()
         let note = SecureNoteGeneratorMock()
@@ -67,7 +66,7 @@ final class GenericVaultItemPreviewViewGeneratorTests {
     }
 
     @Test
-    func makeVaultPreviewView_makesEncryptedItemView() throws {
+    func makeVaultPreviewView_makesEncryptedItemView() {
         let totp = TOTPGeneratorMock()
         let hotp = HOTPGeneratorMock()
         let note = SecureNoteGeneratorMock()

--- a/Vault/Tests/VaultiOSTests/HOTPCodePreviewViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/HOTPCodePreviewViewSnapshotTests.swift
@@ -5,7 +5,6 @@ import Testing
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class HOTPCodePreviewViewSnapshotTests {
     @Test

--- a/Vault/Tests/VaultiOSTests/HOTPPreviewViewGeneratorTests.swift
+++ b/Vault/Tests/VaultiOSTests/HOTPPreviewViewGeneratorTests.swift
@@ -7,7 +7,6 @@ import VaultCore
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class HOTPPreviewViewGeneratorTests {
     @Test
@@ -27,7 +26,7 @@ final class HOTPPreviewViewGeneratorTests {
     }
 
     @Test
-    func makeOTPView_generatesViews() throws {
+    func makeOTPView_generatesViews() {
         let repository = HOTPPreviewViewRepositoryMock()
         repository.previewViewModelHandler = { _, _ in
             MainActor.assumeIsolated {

--- a/Vault/Tests/VaultiOSTests/HorizontalTimerProgressBarViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/HorizontalTimerProgressBarViewSnapshotTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class HorizontalTimerProgressBarViewSnapshotTests {
     @Test

--- a/Vault/Tests/VaultiOSTests/LiteratureViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/LiteratureViewSnapshotTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class LiteratureViewSnapshotTests {
     @Test

--- a/Vault/Tests/VaultiOSTests/OTPCodeDetailViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/OTPCodeDetailViewSnapshotTests.swift
@@ -6,11 +6,10 @@ import VaultFeed
 import VaultSettings
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class OTPCodeDetailViewSnapshotTests {
     @Test
-    func emptyState() async {
+    func emptyState() {
         let sut = OTPCodeDetailView(
             editingExistingCode: .init(type: .totp(period: 30), data: .init(secret: .empty(), accountName: "")),
             navigationPath: .constant(NavigationPath()),
@@ -42,7 +41,7 @@ final class OTPCodeDetailViewSnapshotTests {
     }
 
     @Test
-    func lockedState() async {
+    func lockedState() {
         let sut = OTPCodeDetailView(
             editingExistingCode: .init(type: .totp(period: 30), data: .init(secret: .empty(), accountName: "")),
             navigationPath: .constant(NavigationPath()),
@@ -74,7 +73,7 @@ final class OTPCodeDetailViewSnapshotTests {
     }
 
     @Test
-    func lockedStateNoAuthentication() async {
+    func lockedStateNoAuthentication() {
         let sut = OTPCodeDetailView(
             editingExistingCode: .init(type: .totp(period: 30), data: .init(secret: .empty(), accountName: "")),
             navigationPath: .constant(NavigationPath()),
@@ -106,7 +105,7 @@ final class OTPCodeDetailViewSnapshotTests {
     }
 
     @Test
-    func withUserDescription() async {
+    func withUserDescription() {
         let sut = OTPCodeDetailView(
             editingExistingCode: .init(type: .totp(period: 30), data: .init(secret: .empty(), accountName: "")),
             navigationPath: .constant(NavigationPath()),
@@ -138,7 +137,7 @@ final class OTPCodeDetailViewSnapshotTests {
     }
 
     @Test
-    func editMode_emptyState() async {
+    func editMode_emptyState() {
         let sut = OTPCodeDetailView(
             editingExistingCode: .init(type: .totp(period: 30), data: .init(secret: .empty(), accountName: "")),
             navigationPath: .constant(NavigationPath()),

--- a/Vault/Tests/VaultiOSTests/OTPCodeTextViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/OTPCodeTextViewSnapshotTests.swift
@@ -6,7 +6,6 @@ import VaultFeed
 import VaultiOSShared
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class OTPCodeTextViewSnapshotTests {
     @Test

--- a/Vault/Tests/VaultiOSTests/OpenSourceViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/OpenSourceViewSnapshotTests.swift
@@ -3,7 +3,6 @@ import TestHelpers
 import Testing
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class OpenSourceViewSnapshotTests {
     @Test

--- a/Vault/Tests/VaultiOSTests/PasteboardTests.swift
+++ b/Vault/Tests/VaultiOSTests/PasteboardTests.swift
@@ -7,11 +7,10 @@ import VaultFeed
 import VaultSettings
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class PasteboardTests {
     @Test
-    func init_hasNoSideEffects() async throws {
+    func init_hasNoSideEffects() async {
         let pasteboard = SystemPasteboardMock()
 
         await confirmation(expectedCount: 0) { confirm in
@@ -24,7 +23,7 @@ final class PasteboardTests {
     }
 
     @Test
-    func copy_copiesToPasteboard() async throws {
+    func copy_copiesToPasteboard() async {
         let pasteboard = SystemPasteboardMock()
         let sut = makeSUT(pasteboard: pasteboard)
         let action = VaultTextCopyAction(
@@ -112,7 +111,7 @@ final class PasteboardTests {
     }
 
     @Test
-    func copy_universalClipboardPolicyIsPerType() async throws {
+    func copy_universalClipboardPolicyIsPerType() throws {
         let pasteboard = SystemPasteboardMock()
         let defaults = try makeDefaults()
         let settings = LocalSettings(defaults: defaults)
@@ -147,8 +146,7 @@ extension PasteboardTests {
         file _: StaticString = #filePath,
         line _: UInt = #line,
     ) -> Pasteboard {
-        let pasteboard = Pasteboard(pasteboard, localSettings: localSettings)
-        return pasteboard
+        Pasteboard(pasteboard, localSettings: localSettings)
     }
 
     private func makeDefaults() throws -> Defaults {

--- a/Vault/Tests/VaultiOSTests/QRCodeImageSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/QRCodeImageSnapshotTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 struct QRCodeImageSnapshotTests {
     @Test
-    func image_rendersCode() throws {
+    func image_rendersCode() {
         let sut = QRCodeImage(data: Data(repeating: 0x32, count: 100))
             .frame(width: 100, height: 100)
 

--- a/Vault/Tests/VaultiOSTests/SecureNoteDetailViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/SecureNoteDetailViewSnapshotTests.swift
@@ -5,11 +5,10 @@ import Testing
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class SecureNoteDetailViewSnapshotTests {
     @Test
-    func emptyState() async {
+    func emptyState() {
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "", contents: "", format: .markdown),
             encryptionKey: nil,
@@ -39,7 +38,7 @@ final class SecureNoteDetailViewSnapshotTests {
     }
 
     @Test
-    func lockedState() async {
+    func lockedState() {
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "", contents: "", format: .markdown),
             encryptionKey: nil,
@@ -69,7 +68,7 @@ final class SecureNoteDetailViewSnapshotTests {
     }
 
     @Test
-    func lockedStateNoAuthentication() async {
+    func lockedStateNoAuthentication() {
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "", contents: "", format: .markdown),
             encryptionKey: nil,
@@ -99,7 +98,7 @@ final class SecureNoteDetailViewSnapshotTests {
     }
 
     @Test
-    func titleOnly() async {
+    func titleOnly() {
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "My Title", contents: "", format: .markdown),
             encryptionKey: nil,
@@ -129,7 +128,7 @@ final class SecureNoteDetailViewSnapshotTests {
     }
 
     @Test
-    func titleDescriptionAndShortContent() async {
+    func titleDescriptionAndShortContent() {
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "My Title", contents: "My contents", format: .markdown),
             encryptionKey: nil,
@@ -159,7 +158,7 @@ final class SecureNoteDetailViewSnapshotTests {
     }
 
     @Test
-    func titleDescriptionAndLongContent() async {
+    func titleDescriptionAndLongContent() {
         let longContent = Array(repeating: "My content is cool.", count: 100).joined(separator: " ")
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "My Title", contents: longContent, format: .markdown),
@@ -190,7 +189,7 @@ final class SecureNoteDetailViewSnapshotTests {
     }
 
     @Test
-    func contentUpdated() async {
+    func contentUpdated() {
         let date = fixedTestDate()
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "My Title", contents: "My contents", format: .markdown),
@@ -221,7 +220,7 @@ final class SecureNoteDetailViewSnapshotTests {
     }
 
     @Test
-    func editMode_emptyState() async {
+    func editMode_emptyState() {
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "", contents: "", format: .markdown),
             encryptionKey: nil,
@@ -251,7 +250,7 @@ final class SecureNoteDetailViewSnapshotTests {
     }
 
     @Test
-    func editMode_editedContent() async {
+    func editMode_editedContent() {
         let date = fixedTestDate()
         let sut = SecureNoteDetailView(
             editingExistingNote: .init(title: "My Title", contents: "My contents", format: .markdown),

--- a/Vault/Tests/VaultiOSTests/SecureNotePreviewViewGeneratorTests.swift
+++ b/Vault/Tests/VaultiOSTests/SecureNotePreviewViewGeneratorTests.swift
@@ -8,7 +8,6 @@ import VaultCore
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class SecureNotePreviewViewGeneratorTests {
     @Test
@@ -20,7 +19,7 @@ final class SecureNotePreviewViewGeneratorTests {
     }
 
     @Test
-    func makeVaultPreviewItem_generatesViews() throws {
+    func makeVaultPreviewItem_generatesViews() {
         let factory = SecureNotePreviewViewFactoryMock()
         factory.makeSecureNoteViewHandler = { _, _ in AnyView(Color.red) }
         let sut = makeSUT(factory: factory)
@@ -32,7 +31,7 @@ final class SecureNotePreviewViewGeneratorTests {
     }
 
     @Test
-    func makeVaultPreviewItem_propagatesPreviewMode() throws {
+    func makeVaultPreviewItem_propagatesPreviewMode() {
         let factory = SecureNotePreviewViewFactoryMock()
         var capturedPreviewMode: NotePreviewMode?
         factory.makeSecureNoteViewHandler = { viewModel, _ in

--- a/Vault/Tests/VaultiOSTests/SecureNotePreviewViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/SecureNotePreviewViewSnapshotTests.swift
@@ -5,7 +5,6 @@ import Testing
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class SecureNotePreviewViewSnapshotTests {
     @Test

--- a/Vault/Tests/VaultiOSTests/TOTPCodePreviewViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/TOTPCodePreviewViewSnapshotTests.swift
@@ -5,7 +5,6 @@ import Testing
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class TOTPCodePreviewViewSnapshotTests {
     @Test

--- a/Vault/Tests/VaultiOSTests/TOTPPreviewViewGeneratorTests.swift
+++ b/Vault/Tests/VaultiOSTests/TOTPPreviewViewGeneratorTests.swift
@@ -8,7 +8,6 @@ import VaultCore
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class TOTPPreviewViewGeneratorTests {
     @Test
@@ -28,7 +27,7 @@ final class TOTPPreviewViewGeneratorTests {
     }
 
     @Test
-    func makeOTPView_generatesViews() throws {
+    func makeOTPView_generatesViews() {
         let repository = TOTPPreviewViewRepositoryMock()
         repository.previewViewModelHandler = { _, _ in
             MainActor.assumeIsolated {

--- a/Vault/Tests/VaultiOSTests/VaultDetailKillphraseEditViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/VaultDetailKillphraseEditViewSnapshotTests.swift
@@ -7,7 +7,7 @@ import Testing
 @MainActor
 struct VaultDetailKillphraseEditViewSnapshotTests {
     @Test
-    func layout_notEnabled() async {
+    func layout_notEnabled() {
         let sut = VaultDetailKillphraseEditView(
             title: "This is my title",
             description: "This is my description",
@@ -21,7 +21,7 @@ struct VaultDetailKillphraseEditViewSnapshotTests {
     }
 
     @Test
-    func layout_enabled() async {
+    func layout_enabled() {
         let sut = VaultDetailKillphraseEditView(
             title: "This is my title",
             description: "This is my description",

--- a/Vault/Tests/VaultiOSTests/VaultDetailLockEditViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/VaultDetailLockEditViewSnapshotTests.swift
@@ -7,7 +7,7 @@ import Testing
 @MainActor
 struct VaultDetailLockEditViewSnapshotTests {
     @Test
-    func layout_locked() async {
+    func layout_locked() {
         let sut = VaultDetailLockEditView(
             title: "My title",
             description: "My description",
@@ -19,7 +19,7 @@ struct VaultDetailLockEditViewSnapshotTests {
     }
 
     @Test
-    func layout_notLocked() async {
+    func layout_notLocked() {
         let sut = VaultDetailLockEditView(
             title: "My title",
             description: "My description",

--- a/Vault/Tests/VaultiOSTests/VaultDetailPassphraseEditViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/VaultDetailPassphraseEditViewSnapshotTests.swift
@@ -7,7 +7,7 @@ import Testing
 @MainActor
 struct VaultDetailPassphraseEditViewSnapshotTests {
     @Test
-    func layout_notEnabled() async {
+    func layout_notEnabled() {
         let sut = VaultDetailPassphraseEditView(
             title: "My title",
             description: "This is my description",
@@ -21,7 +21,7 @@ struct VaultDetailPassphraseEditViewSnapshotTests {
     }
 
     @Test
-    func layout_enabled() async {
+    func layout_enabled() {
         let sut = VaultDetailPassphraseEditView(
             title: "My title",
             description: "This is my description",

--- a/Vault/Tests/VaultiOSTests/VaultItemFeedViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/VaultItemFeedViewSnapshotTests.swift
@@ -7,11 +7,10 @@ import VaultFeed
 import VaultSettings
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class VaultItemFeedViewSnapshotTests {
     @Test
-    func layout_noCodes() async throws {
+    func layout_noCodes() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let dataModel = anyVaultDataModel(vaultStore: store, vaultTagStore: tagStore)
@@ -24,7 +23,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func layout_singleCodeAtMediumSize() async throws {
+    func layout_singleCodeAtMediumSize() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         store.retrieveHandler = { _ in .init(items: [uniqueVaultItem()]) }
@@ -38,7 +37,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func layout_multipleCodesAtMediumSize() async throws {
+    func layout_multipleCodesAtMediumSize() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         store.retrieveHandler = { _ in
@@ -58,7 +57,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func viewState_toggleEditingMode() async throws {
+    func viewState_toggleEditingMode() async {
         let state = VaultItemFeedState()
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
@@ -77,7 +76,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func searchBar_includesTagsIfTheyExistInTheVaultStore() async throws {
+    func searchBar_includesTagsIfTheyExistInTheVaultStore() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         tagStore.retrieveTagsHandler = {
@@ -96,7 +95,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func searchBar_tagsBeingFiltered() async throws {
+    func searchBar_tagsBeingFiltered() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let tag1Id = Identifier<VaultItemTag>()
@@ -119,7 +118,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func unifiedBar_searchingWithResults() async throws {
+    func unifiedBar_searchingWithResults() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         store.retrieveHandler = { _ in
@@ -140,7 +139,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func unifiedBar_searchingWithNoResults() async throws {
+    func unifiedBar_searchingWithNoResults() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         store.retrieveHandler = { _ in .init(items: []) }
@@ -156,7 +155,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func unifiedBar_tagFilteringInEditMode() async throws {
+    func unifiedBar_tagFilteringInEditMode() async {
         let state = VaultItemFeedState()
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
@@ -186,7 +185,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func unifiedBar_multipleTagsFiltered() async throws {
+    func unifiedBar_multipleTagsFiltered() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let tag1Id = Identifier<VaultItemTag>()
@@ -217,7 +216,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func unifiedBar_clearButtonVisible() async throws {
+    func unifiedBar_clearButtonVisible() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let tag1Id = Identifier<VaultItemTag>()
@@ -245,7 +244,7 @@ final class VaultItemFeedViewSnapshotTests {
     }
 
     @Test
-    func unifiedBar_narrowWidth_buttonsDoNotWrap() async throws {
+    func unifiedBar_narrowWidth_buttonsDoNotWrap() async {
         let store = VaultStoreStub()
         let tagStore = VaultTagStoreStub()
         let tag1Id = Identifier<VaultItemTag>()

--- a/Vault/Tests/VaultiOSTests/VaultTagFeedViewSnapshotTests.swift
+++ b/Vault/Tests/VaultiOSTests/VaultTagFeedViewSnapshotTests.swift
@@ -5,7 +5,6 @@ import Testing
 import VaultFeed
 @testable import VaultiOS
 
-@Suite
 @MainActor
 final class VaultTagFeedViewSnapshotTests {
     @Test

--- a/Vault/Tests/VaultiOSWidgetsTests/OTPWidgetLoadingTests.swift
+++ b/Vault/Tests/VaultiOSWidgetsTests/OTPWidgetLoadingTests.swift
@@ -4,7 +4,6 @@ import VaultCore
 import VaultFeed
 @testable import VaultiOSWidgets
 
-@Suite
 struct OTPWidgetLoadingTests {
     @Test
     func eligibleItems_retriesAfterStoreOpenFailure() async throws {
@@ -127,7 +126,7 @@ struct OTPWidgetLoadingTests {
     }
 }
 
-private enum WidgetTestError: Error, Equatable, Sendable {
+private enum WidgetTestError: Error, Equatable {
     case open
     case retrieve
 }
@@ -136,7 +135,7 @@ private enum WidgetTestError: Error, Equatable, Sendable {
 // so actor isolation cannot model its scripted open sequence.
 // swiftlint:disable:next no_unchecked_sendable
 private final class StoreFactoryScript: @unchecked Sendable {
-    enum Result: Sendable {
+    enum Result {
         case failure(WidgetTestError)
         case success(any VaultStoreReader)
     }

--- a/Vault/Tests/VaultiOSWidgetsTests/WidgetDeepLinkTests.swift
+++ b/Vault/Tests/VaultiOSWidgetsTests/WidgetDeepLinkTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import Testing
 @testable import VaultiOSShared
 
-@Suite
 struct WidgetDeepLinkTests {
     @Test
     func hotpIncrement_roundTripsViaParse() {


### PR DESCRIPTION
## Summary
- Updates SwiftLintPlugins to 0.63.3 and SwiftFormat to 0.61.1
- Applies the updated SwiftFormat output
- Preserves existing Swift Testing test case names with `--test-case-name-format preserve`

## Verification
- `make lint && make format`
- `git diff --check`