### PR TITLE
Fix Fastlane release lane export

### DIFF
--- a/Vault/.swiftformat
+++ b/Vault/.swiftformat
@@ -42,3 +42,4 @@
 --enable todos
 --enable throwingTests
 --disable hoistAwait
+--disable redundantThrows

--- a/Vault/Sources/CryptoEngine/Key Derivation/KeyDeriver.swift
+++ b/Vault/Sources/CryptoEngine/Key Derivation/KeyDeriver.swift
@@ -21,7 +21,7 @@ public struct FailingKeyDeriver<let bytes: Int>: KeyDeriver {
     public init() {}
 
     public struct KeyDeriverError: Error {}
-    public func key(password _: Data, salt _: Data) throws(KeyDeriverError) -> KeyData<bytes> {
+    public func key(password _: Data, salt _: Data) throws -> KeyData<bytes> {
         throw KeyDeriverError()
     }
 

--- a/Vault/Tests/FoundationExtensionsTests/LeakTrackingTests.swift
+++ b/Vault/Tests/FoundationExtensionsTests/LeakTrackingTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 struct LeakTrackingTests {
     @Test @LeakTracked
-    func cleanDeallocation_recordsNoIssue() {
+    func cleanDeallocation_recordsNoIssue() throws {
         _ = trackForMemoryLeaks(Probe())
     }
 
@@ -28,13 +28,13 @@ struct LeakTrackingTests {
 
     @Test @LeakTracked
     @MainActor
-    func mainActor_cleanDeallocation_recordsNoIssue() {
+    func mainActor_cleanDeallocation_recordsNoIssue() throws {
         _ = trackForMemoryLeaks(Probe())
     }
 
     @Test @LeakTracked
     @MainActor
-    func mainActor_async_cleanDeallocation_recordsNoIssue() {
+    func mainActor_async_cleanDeallocation_recordsNoIssue() throws {
         _ = trackForMemoryLeaks(Probe())
     }
 }

--- a/Vault/Tests/VaultFeedTests/Presentation/BackupKeyDecryptorViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/BackupKeyDecryptorViewModelTests.swift
@@ -9,7 +9,7 @@ import VaultKeygen
 @MainActor
 struct BackupKeyDecryptorViewModelTests {
     @Test @LeakTracked
-    func init_setsInitialState() {
+    func init_setsInitialState() throws {
         let sut = makeSUT()
 
         #expect(sut.enteredPassword == "")
@@ -17,7 +17,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func canAttemptDecryption_falseIfPasswordEmpty() {
+    func canAttemptDecryption_falseIfPasswordEmpty() throws {
         let sut = makeSUT()
         sut.enteredPassword = ""
 
@@ -25,7 +25,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func canAttemptDecryption_trueIfPasswordNotEmpty() {
+    func canAttemptDecryption_trueIfPasswordNotEmpty() throws {
         let sut = makeSUT()
         sut.enteredPassword = "a"
 
@@ -33,7 +33,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func attemptDecryption_validPasswordGeneratesConsistentlyWithSalt() async {
+    func attemptDecryption_validPasswordGeneratesConsistentlyWithSalt() async throws {
         let vaultApplicationPayload = VaultApplicationPayload(userDescription: "my stuff", items: [], tags: [])
         let decoder = EncryptedVaultDecoderMock()
         // returned payload implies successful decryption
@@ -64,7 +64,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func generateKey_emptyPasswordGeneratesError() async {
+    func generateKey_emptyPasswordGeneratesError() async throws {
         let decoder = EncryptedVaultDecoderMock()
         decoder.verifyCanDecryptHandler = { _, _ in throw TestError() }
         let sut = makeSUT(encryptedVaultDecoder: decoder)
@@ -76,7 +76,7 @@ struct BackupKeyDecryptorViewModelTests {
     }
 
     @Test @LeakTracked
-    func generateKey_keyDeriverErrorGeneratesError() async {
+    func generateKey_keyDeriverErrorGeneratesError() async throws {
         let sut = makeSUT(keyDeriverFactory: .failing)
         sut.enteredPassword = "hello"
 

--- a/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeIncrementerViewModelTests.swift
+++ b/Vault/Tests/VaultFeedTests/Presentation/OTPCode/OTPCodeIncrementerViewModelTests.swift
@@ -8,7 +8,7 @@ import VaultFeed
 @MainActor
 struct OTPCodeIncrementerViewModelTests {
     @Test @LeakTracked
-    func isButtonEnabled_isInitiallyTrue() {
+    func isButtonEnabled_isInitiallyTrue() throws {
         let sut = makeSUT()
 
         #expect(sut.isButtonEnabled)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -64,7 +64,8 @@ platform :ios do
       gym(
         workspace: "Vault.xcworkspace",
         scheme: "VaultApp",
-        export_method: "app-store-connect",
+        # Fastlane 2.235 still validates the pre-Xcode-26 name; Xcode accepts it with a warning.
+        export_method: "app-store",
         export_options: {
           provisioningProfiles: {
             "com.badbundle.vault" => "vault.mobileprovision",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -72,8 +72,8 @@ platform :ios do
       },
       clean: true,
       export_team_id: "442P244AFS",
-      # Use xcargs to pass additional options
-      xcargs: "-allowProvisioningUpdates CURRENT_PROJECT_VERSION=#{release_build_number}"
+      # Allow non-interactive release archives to run approved SwiftPM build tool plugins.
+      xcargs: "-allowProvisioningUpdates -skipPackagePluginValidation CURRENT_PROJECT_VERSION=#{release_build_number}"
     )
     
     # Upload to App Store using the correct Apple ID

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,33 +54,44 @@ platform :ios do
     get_provisioning_profile(app_identifier: "com.badbundle.vault.VaultAutofill")
     get_provisioning_profile(app_identifier: "com.badbundle.vault.Widgets")
 
-    original_path = ENV["PATH"]
-    # Xcode's export step launches /usr/bin/rsync, which can spawn an rsync helper from PATH.
-    # Keep Apple's system bins first so Homebrew rsync does not reject Apple's xattr flags.
-    ENV["PATH"] = ["/usr/bin", "/bin", "/usr/sbin", "/sbin", original_path].compact.join(":")
+    export_options = {
+      provisioningProfiles: {
+        "com.badbundle.vault" => "vault.mobileprovision",
+        "com.badbundle.vault.VaultAutofill" => "vault-autofill.mobileprovision",
+        "com.badbundle.vault.Widgets" => "vault-widgets.mobileprovision"
+      },
+      uploadSymbols: true,
+      uploadBitcode: false,
+      # Keep Xcode from mutating App Store Connect version/build metadata during export.
+      manageAppVersionAndBuildNumber: false
+    }
 
+    # Archive with the normal PATH so the configured xcodebuild formatter uses the active Ruby toolchain.
+    archive_path = gym(
+      workspace: "Vault.xcworkspace",
+      scheme: "VaultApp",
+      clean: true,
+      skip_package_ipa: true,
+      # Allow non-interactive release archives to run approved SwiftPM build tool plugins.
+      xcargs: "-allowProvisioningUpdates -skipPackagePluginValidation CURRENT_PROJECT_VERSION=#{release_build_number}"
+    )
+
+    original_path = ENV["PATH"]
     begin
-      # Build and export with the release signing profile set.
+      # Xcode's export step launches /usr/bin/rsync, which can spawn an rsync helper from PATH.
+      # Keep Apple's system bins first so Homebrew rsync does not reject Apple's xattr flags.
+      ENV["PATH"] = ["/usr/bin", "/bin", "/usr/sbin", "/sbin", original_path].compact.join(":")
+
       gym(
         workspace: "Vault.xcworkspace",
         scheme: "VaultApp",
+        archive_path: archive_path,
+        skip_build_archive: true,
         # Fastlane 2.235 still validates the pre-Xcode-26 name; Xcode accepts it with a warning.
         export_method: "app-store",
-        export_options: {
-          provisioningProfiles: {
-            "com.badbundle.vault" => "vault.mobileprovision",
-            "com.badbundle.vault.VaultAutofill" => "vault-autofill.mobileprovision",
-            "com.badbundle.vault.Widgets" => "vault-widgets.mobileprovision"
-          },
-          uploadSymbols: true,
-          uploadBitcode: false,
-          # Keep Xcode from mutating App Store Connect version/build metadata during export.
-          manageAppVersionAndBuildNumber: false
-        },
-        clean: true,
+        export_options: export_options,
         export_team_id: "442P244AFS",
-        # Allow non-interactive release archives to run approved SwiftPM build tool plugins.
-        xcargs: "-allowProvisioningUpdates -skipPackagePluginValidation CURRENT_PROJECT_VERSION=#{release_build_number}"
+        export_xcargs: "-allowProvisioningUpdates"
       )
     ensure
       ENV["PATH"] = original_path

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -54,27 +54,36 @@ platform :ios do
     get_provisioning_profile(app_identifier: "com.badbundle.vault.VaultAutofill")
     get_provisioning_profile(app_identifier: "com.badbundle.vault.Widgets")
 
-    # Build and export - skip validation during export to avoid auth issues
-    gym(
-      workspace: "Vault.xcworkspace",
-      scheme: "VaultApp",
-      export_method: "app-store",
-      export_options: {
-        provisioningProfiles: {
-          "com.badbundle.vault" => "vault.mobileprovision",
-          "com.badbundle.vault.VaultAutofill" => "vault-autofill.mobileprovision",
-          "com.badbundle.vault.Widgets" => "vault-widgets.mobileprovision"
+    original_path = ENV["PATH"]
+    # Xcode's export step launches /usr/bin/rsync, which can spawn an rsync helper from PATH.
+    # Keep Apple's system bins first so Homebrew rsync does not reject Apple's xattr flags.
+    ENV["PATH"] = ["/usr/bin", "/bin", "/usr/sbin", "/sbin", original_path].compact.join(":")
+
+    begin
+      # Build and export with the release signing profile set.
+      gym(
+        workspace: "Vault.xcworkspace",
+        scheme: "VaultApp",
+        export_method: "app-store-connect",
+        export_options: {
+          provisioningProfiles: {
+            "com.badbundle.vault" => "vault.mobileprovision",
+            "com.badbundle.vault.VaultAutofill" => "vault-autofill.mobileprovision",
+            "com.badbundle.vault.Widgets" => "vault-widgets.mobileprovision"
+          },
+          uploadSymbols: true,
+          uploadBitcode: false,
+          # Keep Xcode from mutating App Store Connect version/build metadata during export.
+          manageAppVersionAndBuildNumber: false
         },
-        uploadSymbols: true,
-        uploadBitcode: false,
-        # This is the key - skip the Apple validation during export
-        manageAppVersionAndBuildNumber: false
-      },
-      clean: true,
-      export_team_id: "442P244AFS",
-      # Allow non-interactive release archives to run approved SwiftPM build tool plugins.
-      xcargs: "-allowProvisioningUpdates -skipPackagePluginValidation CURRENT_PROJECT_VERSION=#{release_build_number}"
-    )
+        clean: true,
+        export_team_id: "442P244AFS",
+        # Allow non-interactive release archives to run approved SwiftPM build tool plugins.
+        xcargs: "-allowProvisioningUpdates -skipPackagePluginValidation CURRENT_PROJECT_VERSION=#{release_build_number}"
+      )
+    ensure
+      ENV["PATH"] = original_path
+    end
     
     # Upload to App Store using the correct Apple ID
     upload_to_app_store(

--- a/fastlane/metadata/copyright.txt
+++ b/fastlane/metadata/copyright.txt
@@ -1,1 +1,1 @@
-2024 Bad Bundle Limited
+2026 Bad Bundle Limited

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-2fa,backup,secure,note,authenticator,google,authy,paper,pdf,qr,code,encrypted
+2fa,backup,secure,note,authenticator,totp,authy,paper,pdf,qr,code,encrypted


### PR DESCRIPTION
## Summary
- skip SwiftPM build tool plugin validation during release archives
- keep Fastlane on the supported app-store export method while noting the Xcode deprecation warning
- split archive and export so archive formatting uses the normal Ruby toolchain and export uses Apple system tools ahead of Homebrew rsync
- avoid Xcode mutating App Store Connect version/build metadata during export
- remove the prohibited google keyword from App Store metadata and update copyright to 2026
- disable SwiftFormat redundantThrows so test methods can intentionally remain throws

## Verification
- make format
- make lint
- release lane verified locally through archive/export/upload flow after the Fastfile fix
- export-only gym check produced a signed IPA from the existing archive
- metadata-only fastlane deliver uploaded App Store metadata for version 2.0