### PR TITLE
Compile CI_iOS on GitHub Actions

### DIFF
--- a/.github/workflows/validate-all.yml
+++ b/.github/workflows/validate-all.yml
@@ -78,9 +78,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-ci-ios-xcode-${{ env.XCODE_VERSION }}-
 
-      - name: Test CI_iOS
+      - name: Build CI_iOS
         run: |
-          xcodebuild test \
+          xcodebuild build-for-testing \
             -workspace Vault.xcworkspace \
             -scheme CI_iOS \
             -testPlan iOSAllTests \

--- a/.github/workflows/validate-all.yml
+++ b/.github/workflows/validate-all.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
 
 env:
-  XCODE_VERSION: "26.1"
+  XCODE_VERSION: "26.5"
 
 jobs:
   release-config:
@@ -51,33 +51,39 @@ jobs:
           path: |
             ~/Library/Caches/org.swift.swiftpm/repositories
             Vault/.build
-          key: ${{ runner.os }}-spm-lint-${{ hashFiles('Vault/Package.resolved') }}
+          key: ${{ runner.os }}-spm-lint-xcode-${{ env.XCODE_VERSION }}-${{ hashFiles('Vault/Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-spm-lint-
+            ${{ runner.os }}-spm-lint-xcode-${{ env.XCODE_VERSION }}-
 
       - name: Check Linting & Formatting
         run: make lint
 
-  # Don't test for now to save CI time
-  # test:
-  #   name: Test
-  #   timeout-minutes: 10
-  #   runs-on: macos-26
-  #
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
-  #
-  #     - name: Cache SPM Dependencies
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: ~/Library/Caches/org.swift.swiftpm/repositories
-  #         key: ${{ runner.os }}-spm-${{ hashFiles('Vault/Package.resolved') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-spm-
-  #
-  #     - name: Clear SPM Artifacts
-  #       run: rm -rf ~/Library/Caches/org.swift.swiftpm/artifacts
-  #
-  #     - name: Test CI_macOS
-  #       run: xcodebuild test -workspace Vault.xcworkspace -scheme CI_macOS -skipMacroValidation -skipPackagePluginValidation
+  ci-ios:
+    name: CI_iOS
+    timeout-minutes: 20
+    runs-on: macos-26
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+
+      - name: Log Xcode Version
+        run: xcodebuild -version
+
+      - name: Cache SPM Dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Caches/org.swift.swiftpm/repositories
+          key: ${{ runner.os }}-spm-ci-ios-xcode-${{ env.XCODE_VERSION }}-${{ hashFiles('Vault/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-ci-ios-xcode-${{ env.XCODE_VERSION }}-
+
+      - name: Test CI_iOS
+        run: |
+          xcodebuild test \
+            -workspace Vault.xcworkspace \
+            -scheme CI_iOS \
+            -testPlan iOSAllTests \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
+            -skipMacroValidation \
+            -skipPackagePluginValidation


### PR DESCRIPTION
## Summary
- Select Xcode 26.5 for validation jobs.
- Scope SwiftPM cache keys by Xcode version.
- Enable a compile-only CI_iOS job on the standard macos-26 runner using the iPhone 17 Pro iOS 26.5 simulator destination.

## Validation
- YAML parse: OK
- `git diff --check`: OK
- `make lint` from `Vault/`: passed before this compile-only follow-up
