### PR TITLE
[codex] Update CryptoSwift to 1.10.0

### DIFF
--- a/Vault.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vault.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "332cf84c951ee0268d8ce5668c10a80018712bea3a79b059460d0f3e8b0b61ae",
+  "originHash" : "5a8160676b0f4c9b1a971211509ae4ef5a15f6f5a49d3f101f2614b35a1f066c",
   "pins" : [
     {
       "identity" : "bigint",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {

--- a/Vault/Package.resolved
+++ b/Vault/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "332cf84c951ee0268d8ce5668c10a80018712bea3a79b059460d0f3e8b0b61ae",
+  "originHash" : "5a8160676b0f4c9b1a971211509ae4ef5a15f6f5a49d3f101f2614b35a1f066c",
   "pins" : [
     {
       "identity" : "bigint",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift",
       "state" : {
-        "revision" : "e45a26384239e028ec87fbcc788f513b67e10d8f",
-        "version" : "1.9.0"
+        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
+        "version" : "1.10.0"
       }
     },
     {

--- a/Vault/Package.swift
+++ b/Vault/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing", exact: "1.18.7"),
         .package(url: "https://github.com/attaswift/BigInt.git", exact: "5.7.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift", exact: "1.9.0"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift", exact: "1.10.0"),
         .package(url: "https://github.com/sunghyun-k/swiftui-toasts.git", exact: "0.2.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.6.2"),
         .package(url: "https://github.com/twostraws/CodeScanner", exact: "2.5.2"),


### PR DESCRIPTION
## Summary

Updates the direct Swift package dependency `CryptoSwift` from `1.9.0` to `1.10.0`.

SwiftPM refreshed both `Vault/Package.resolved` and the root workspace `Package.resolved`, keeping the package and Xcode workspace lockfiles aligned.

## Impact

This keeps the crypto dependency current while leaving the rest of the package graph unchanged.

## Validation

- `make format`
- `make lint`
- `xcodebuild test -workspace /Users/bradley/Developer/Code/vault-ios/Vault.xcworkspace -scheme CryptoEngineTests -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5'`
