### PR TITLE
Shard CI_iOS test suites

### DIFF
--- a/.github/workflows/validate-all.yml
+++ b/.github/workflows/validate-all.yml
@@ -161,7 +161,8 @@ jobs:
           xcodebuild test-without-building \
             -xctestrun "$XCTESTRUN" \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
-            -only-testing:${{ matrix.only_testing }}
+            -only-testing:${{ matrix.only_testing }} \
+            -parallel-testing-enabled NO
 
   ci-ios:
     name: CI_iOS

--- a/.github/workflows/validate-all.yml
+++ b/.github/workflows/validate-all.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Check Linting & Formatting
         run: make lint
 
-  ci-ios:
-    name: CI_iOS
+  ci-ios-build:
+    name: CI_iOS Build
     timeout-minutes: 20
     runs-on: macos-26
 
@@ -85,5 +85,96 @@ jobs:
             -scheme CI_iOS \
             -testPlan iOSAllTests \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
+            -derivedDataPath "$RUNNER_TEMP/ci-ios-derived-data" \
             -skipMacroValidation \
             -skipPackagePluginValidation
+
+      - name: Package CI_iOS Test Products
+        run: tar -czf "$RUNNER_TEMP/ci-ios-test-products.tgz" -C "$RUNNER_TEMP/ci-ios-derived-data/Build" Products
+
+      - name: Upload CI_iOS Test Products
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-ios-test-products
+          path: ${{ runner.temp }}/ci-ios-test-products.tgz
+          if-no-files-found: error
+          retention-days: 1
+
+  ci-ios-tests:
+    name: CI_iOS Tests (${{ matrix.suite }})
+    timeout-minutes: 20
+    runs-on: macos-26
+    needs: ci-ios-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: VaultiOSTests
+            only_testing: VaultiOSTests
+          - suite: VaultSettingsTests
+            only_testing: VaultSettingsTests
+          - suite: FoundationExtensionsTests
+            only_testing: FoundationExtensionsTests
+          - suite: ImageToolsTests
+            only_testing: ImageToolsTests
+          - suite: VaultiOSAutofillTests
+            only_testing: VaultiOSAutofillTests
+          - suite: VaultiOSWidgetsTests
+            only_testing: VaultiOSWidgetsTests
+          - suite: VaultFeedTests
+            only_testing: VaultFeedTests
+          - suite: VaultKeygenTests
+            only_testing: VaultKeygenTests
+          - suite: VaultCoreTests
+            only_testing: VaultCoreTests
+          - suite: VaultKeygenSpeedtestCompileTests
+            only_testing: VaultKeygenSpeedtestCompileTests
+          - suite: VaultExportTests
+            only_testing: VaultExportTests
+          - suite: VaultBackupTests
+            only_testing: VaultBackupTests
+          - suite: CryptoEngineTests
+            only_testing: CryptoEngineTests
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+
+      - name: Download CI_iOS Test Products
+        uses: actions/download-artifact@v4
+        with:
+          name: ci-ios-test-products
+          path: ${{ runner.temp }}
+
+      - name: Run CI_iOS Tests
+        run: |
+          mkdir -p "$RUNNER_TEMP/ci-ios-derived-data/Build"
+          tar -xzf "$RUNNER_TEMP/ci-ios-test-products.tgz" -C "$RUNNER_TEMP/ci-ios-derived-data/Build"
+
+          XCTESTRUN="$(find "$RUNNER_TEMP/ci-ios-derived-data/Build/Products" -maxdepth 1 -name '*.xctestrun' -print -quit)"
+
+          if [[ -z "$XCTESTRUN" ]]; then
+            echo "No .xctestrun file found in downloaded CI_iOS test products."
+            exit 1
+          fi
+
+          xcodebuild test-without-building \
+            -xctestrun "$XCTESTRUN" \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' \
+            -only-testing:${{ matrix.only_testing }}
+
+  ci-ios:
+    name: CI_iOS
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    needs: [ci-ios-build, ci-ios-tests]
+    if: always()
+
+    steps:
+      - name: Check CI_iOS Shards
+        run: |
+          if [[ "${{ needs.ci-ios-build.result }}" != "success" || "${{ needs.ci-ios-tests.result }}" != "success" ]]; then
+            echo "CI_iOS build result: ${{ needs.ci-ios-build.result }}"
+            echo "CI_iOS tests result: ${{ needs.ci-ios-tests.result }}"
+            exit 1
+          fi

--- a/Vault/Tests/VaultCoreTests/Clock/IntervalTimerTests.swift
+++ b/Vault/Tests/VaultCoreTests/Clock/IntervalTimerTests.swift
@@ -74,8 +74,7 @@ enum IntervalTimerTests {
                     }
                 }
 
-                // Give tasks time to start and register their waits
-                await Task.yield()
+                try await waitForRegisteredWaits(count: 3)
 
                 try await sut.finishTimer(at: 0)
                 try await sut.finishTimer(at: 1)
@@ -116,6 +115,15 @@ enum IntervalTimerTests {
             await #expect(throws: TimeoutError.self, performing: {
                 try await sut.finishTimer(at: 0)
             })
+        }
+
+        private func waitForRegisteredWaits(count: Int) async throws {
+            try await Task.withTimeout(delay: .seconds(1), priority: .high) {
+                while sut.waitArgValues.count < count {
+                    try Task.checkCancellation()
+                    await Task.yield()
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This updates the iOS CI workflow so CI_iOS builds test products once, uploads them as a tarred artifact, then runs each test target as a parallel test-without-building shard.

## Why

The previous workflow stopped at build-for-testing, so it compiled iOS test products but did not run the test suites. Running everything serially in one job would add significant wall-clock time. Sharding keeps full test coverage while reducing elapsed time to roughly build time plus the slowest suite and artifact transfer.

## Impact

The required CI_iOS check name is preserved as an aggregate job. Individual shard jobs expose failures per test target, and the build artifact uses RUNNER_TEMP to avoid workspace churn.

## Validation

- make format
- make lint
- ruby YAML parse for .github/workflows/validate-all.yml
- git diff --check
- local xcodebuild test-without-building enumeration for VaultCoreTests