### PR TITLE
Update swift-security to 2.5.1

### DIFF
--- a/Vault.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vault.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d043e3ea53bbfc3b139fe272b4d26da3cf79efd2353b8fe2c7e309ad120aa81f",
+  "originHash" : "53caa1a3fa2e098bae16dc5c68443167bcba237c985d14dc72a27a1c1f6f2dac",
   "pins" : [
     {
       "identity" : "bigint",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dm-zharov/swift-security.git",
       "state" : {
-        "revision" : "d29203624538b6fdcd465ae9086510f652df057b",
-        "version" : "2.5.0"
+        "revision" : "7b17d3b0e9974d69082c1ef2d5b6504033470fd1",
+        "version" : "2.5.1"
       }
     },
     {

--- a/Vault/Package.resolved
+++ b/Vault/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d043e3ea53bbfc3b139fe272b4d26da3cf79efd2353b8fe2c7e309ad120aa81f",
+  "originHash" : "53caa1a3fa2e098bae16dc5c68443167bcba237c985d14dc72a27a1c1f6f2dac",
   "pins" : [
     {
       "identity" : "bigint",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dm-zharov/swift-security.git",
       "state" : {
-        "revision" : "d29203624538b6fdcd465ae9086510f652df057b",
-        "version" : "2.5.0"
+        "revision" : "7b17d3b0e9974d69082c1ef2d5b6504033470fd1",
+        "version" : "2.5.1"
       }
     },
     {

--- a/Vault/Package.swift
+++ b/Vault/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/sunghyun-k/swiftui-toasts.git", exact: "0.2.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.6.2"),
         .package(url: "https://github.com/twostraws/CodeScanner", exact: "2.5.2"),
-        .package(url: "https://github.com/dm-zharov/swift-security.git", exact: "2.5.0"),
+        .package(url: "https://github.com/dm-zharov/swift-security.git", exact: "2.5.1"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", exact: "2.4.1"),
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: swiftLintVersion),
         .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),


### PR DESCRIPTION
## Summary
- Update swift-security exact dependency pin from 2.5.0 to 2.5.1.
- Refresh SwiftPM lockfiles for the package and workspace.

## Impact
- Dependency-only update. Upstream 2.5.1 release notes mention test host/settings cleanup and compile warning fixes.

## Validation
- make format
- make lint
- swift package resolve
- xcodebuild -list -workspace Vault.xcworkspace confirmed swift-security @ 2.5.1
- xcodebuild test -workspace Vault.xcworkspace -scheme CI_iOS -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5" -skipPackagePluginValidation ran 3606 tests; build passed, with one existing-looking snapshot mismatch in SecureNoteDetailViewSnapshotTests.editMode_editedContent across six variants.