### PR TITLE
Fix IntervalTimer mock wait flake

### DIFF
--- a/Vault/Tests/VaultCoreTests/Clock/IntervalTimerTests.swift
+++ b/Vault/Tests/VaultCoreTests/Clock/IntervalTimerTests.swift
@@ -67,7 +67,7 @@ enum IntervalTimerTests {
         @Test
         func wait_multipleWaitsCanCompleteIndependently() async throws {
             try await confirmation(timeout: .seconds(10), expectedCount: 3) { confirmation in
-                for _ in 0 ..< 3 {
+                let waitTasks = (0 ..< 3).map { _ in
                     Task(priority: .high) {
                         try await sut.wait(for: 10)
                         confirmation.confirm()
@@ -79,6 +79,10 @@ enum IntervalTimerTests {
                 try await sut.finishTimer(at: 0)
                 try await sut.finishTimer(at: 1)
                 try await sut.finishTimer(at: 2)
+
+                for task in waitTasks {
+                    try await task.value
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Await the three `IntervalTimerMock` wait tasks before the confirmation scope exits.
- Prevent CI from observing only 1-2 confirmations in `wait_multipleWaitsCanCompleteIndependently()`.

## Root Cause
The test launched unstructured tasks, finished all mock timers, then let `confirmation` validate before every child task necessarily reached `confirmation.confirm()`.

## Validation
- `xcodebuild test -workspace Vault.xcworkspace -scheme CI_iOS -testPlan iOSAllTests -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5" -only-testing:VaultCoreTests -parallel-testing-enabled NO -derivedDataPath /private/tmp/vault-ios-ci-fix-derived-data -skipMacroValidation -skipPackagePluginValidation`
- `make format`
- `make lint`