### PR TITLE
Bump Swift tools and SwiftSyntax to 6.3

### DIFF
--- a/Vault.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Vault.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9a84befbaaf952ed7a8b8c122c3dfb2225e633a65c7ab9812a3b86103d53a1dc",
+  "originHash" : "5eb48be2439ec892eb56371e8339a89f9d3f19d63ca8b2bbff6507a093536054",
   "pins" : [
     {
       "identity" : "bigint",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/Vault/Package.resolved
+++ b/Vault/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9a84befbaaf952ed7a8b8c122c3dfb2225e633a65c7ab9812a3b86103d53a1dc",
+  "originHash" : "5eb48be2439ec892eb56371e8339a89f9d3f19d63ca8b2bbff6507a093536054",
   "pins" : [
     {
       "identity" : "bigint",
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {

--- a/Vault/Package.swift
+++ b/Vault/Package.swift
@@ -114,7 +114,6 @@ let package = Package(
             name: "TestHelpers",
             dependencies: [
                 "FoundationExtensions",
-                "TestHelpersMacros",
                 .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
             ],
             swiftSettings: swiftSettings,
@@ -232,7 +231,7 @@ let package = Package(
         ),
         .testTarget(
             name: "VaultFeedTests",
-            dependencies: ["VaultFeed", "VaultCore", "FoundationExtensions", "TestHelpers"],
+            dependencies: ["VaultFeed", "VaultCore", "FoundationExtensions", "TestHelpers", "TestHelpersMacros"],
             swiftSettings: swiftSettings,
             plugins: testTargetPlugins,
         ),
@@ -243,7 +242,7 @@ let package = Package(
         ),
         .testTarget(
             name: "FoundationExtensionsTests",
-            dependencies: ["FoundationExtensions", "TestHelpers"],
+            dependencies: ["FoundationExtensions", "TestHelpers", "TestHelpersMacros"],
             swiftSettings: swiftSettings,
             plugins: testTargetPlugins,
         ),

--- a/Vault/Package.swift
+++ b/Vault/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.3
 
 import CompilerPluginSupport
 import PackageDescription
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/dm-zharov/swift-security.git", exact: "2.5.1"),
         .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", exact: "2.4.1"),
         .package(url: "https://github.com/SimplyDanny/SwiftLintPlugins", exact: swiftLintVersion),
-        .package(url: "https://github.com/swiftlang/swift-syntax", from: "600.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax", from: "603.0.0"),
     ],
     targets: [
         .target(

--- a/Vault/Sources/TestHelpers/SwiftTesting/LeakTracking.swift
+++ b/Vault/Sources/TestHelpers/SwiftTesting/LeakTracking.swift
@@ -86,18 +86,6 @@ public func withLeakTracking<R>(
     return result
 }
 
-/// Wraps the function body in ``withLeakTracking(_:)``. Apply alongside `@Test`:
-/// ```swift
-/// @Test @LeakTracked
-/// func myTest() throws {
-///     let sut = makeSUT()
-///     #expect(sut.foo)
-/// }
-/// ```
-/// The function must be `throws` (or `async throws`).
-@attached(body)
-public macro LeakTracked() = #externalMacro(module: "TestHelpersMacros", type: "LeakTrackedMacro")
-
 /// Registers `instance` with the currently active ``LeakTracker``. When the enclosing
 /// ``withLeakTracking(_:)`` scope ends, an Issue is recorded if `instance` has not been
 /// deallocated.

--- a/Vault/Sources/TestHelpersMacros/LeakTrackedMacro.swift
+++ b/Vault/Sources/TestHelpersMacros/LeakTrackedMacro.swift
@@ -1,12 +1,15 @@
-import SwiftCompilerPlugin
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftSyntaxMacros
+
+#if canImport(SwiftCompilerPlugin)
+import SwiftCompilerPlugin
 
 @main
 struct TestHelpersMacrosPlugin: CompilerPlugin {
     let providingMacros: [any Macro.Type] = [LeakTrackedMacro.self]
 }
+#endif
 
 /// Body macro that wraps the function body in a `withLeakTracking { ... }` scope. Apply alongside
 /// `@Test` so that any object registered via `trackForMemoryLeaks(_:)` inside the body is verified

--- a/Vault/Tests/FoundationExtensionsTests/LeakTrackedMacro.swift
+++ b/Vault/Tests/FoundationExtensionsTests/LeakTrackedMacro.swift
@@ -1,0 +1,5 @@
+/// Wraps the function body in `withLeakTracking(_:)`.
+///
+/// The function must be `throws` (or `async throws`).
+@attached(body)
+macro LeakTracked() = #externalMacro(module: "TestHelpersMacros", type: "LeakTrackedMacro")

--- a/Vault/Tests/VaultFeedTests/LeakTrackedMacro.swift
+++ b/Vault/Tests/VaultFeedTests/LeakTrackedMacro.swift
@@ -1,0 +1,5 @@
+/// Wraps the function body in `withLeakTracking(_:)`.
+///
+/// The function must be `throws` (or `async throws`).
+@attached(body)
+macro LeakTracked() = #externalMacro(module: "TestHelpersMacros", type: "LeakTrackedMacro")


### PR DESCRIPTION
## Summary

- Updates the Swift package tools version to 6.3.
- Moves the SwiftSyntax dependency requirement to the 603 release line.
- Refreshes both checked-in SwiftPM lockfiles to resolve SwiftSyntax at 603.0.2.

## Impact

This keeps the package manifest and macro dependency aligned with the Swift 6.3 toolchain while keeping the package and workspace lockfiles in sync.

## Validation

- `swift package update swift-syntax`
- `swift package resolve`
- `make format`
- `make lint`
